### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ env OCTAGON_API_KEY=your_octagon_api_key npx -y octagon-mcp
 npm install -g octagon-mcp
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/octagonai-octagon-mcp-server).
+
 ## Documentation
 
 For comprehensive documentation on using Octagon agents, please visit our official documentation at:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/octagonai-octagon-mcp-server).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about a hosted MCP deployment option available through Fronteir AI with a direct link to the hosted server for convenient access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->