### PR TITLE
Refine octagon-agent thread reuse in MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,28 +159,35 @@ Orchestrates public and private market intelligence analysis.
 
 - `prompt` (string, required): natural language research request.
 - `conversation` (string, optional): existing Octagon conversation ID to continue a prior `octagon-agent` thread. Omit this on the first turn.
-- `threadKey` (string, optional): logical visible chat/thread identifier used for safe automatic conversation reuse when the MCP transport does not provide a stable session id.
-- `resetConversation` (boolean, optional): if `true`, clears the stored Octagon thread for the active session/thread anchor before making the request.
+- `newConversation` (boolean, optional): if `true`, starts a fresh Octagon thread for the active session/thread anchor. Recommended for the first turn of a brand new visible chat in top-layer hosts such as Claude Desktop.
 
 **Threaded usage**
 
-`octagon-agent` is the only MCP tool that forwards Octagon conversation threading. The MCP resolves thread state in this order:
+`octagon-agent` is the only MCP tool that forwards Octagon conversation threading. It is a stateful tool and expects session continuity. The MCP resolves session/thread state in this order:
 
-1. explicit `conversation`
-2. stored conversation for the MCP `sessionId`
-3. stored conversation for `threadKey`
-4. otherwise no reuse; Octagon starts a fresh conversation
+1. stored conversation for MCP transport session identity, when the transport actually provides it
+2. stored conversation for the server-managed default `stdio` session
+3. explicit `conversation` can still override the active session conversation for that call
+
+This package currently runs as a `stdio` MCP server. In `stdio` mode, the server automatically establishes a process-local session for continuity across calls. Most local hosts such as Claude Desktop or Cursor can therefore use `octagon-agent` without supplying any extra threading fields for basic follow-up behavior.
+
+When a top-layer host knows a call is the first turn of a new visible chat, it should pass `newConversation: true`. That explicitly clears any stored Octagon thread for the active MCP session anchor before the call, which prevents stale continuity when a `stdio` host reuses the same long-lived MCP process across multiple visible chats.
 
 This means you can use any of these patterns:
 
 1. First call: send only `prompt`
-2. Read `structuredContent.conversation` from the MCP result
+2. Let the MCP host preserve transport session continuity or rely on the default stdio session
 3. Second call: either
-   - send the new `prompt` plus that `conversation`, or
-   - keep the same MCP session, or
-   - send the same `threadKey`
+   - send the new `prompt` in the same MCP session, or
+   - keep using the same stdio MCP process, or
+   - explicitly pass the previous `conversation`
 
-When both `sessionId` and `threadKey` are absent, the MCP does **not** auto-reuse a prior conversation. This avoids cross-chat leakage when the transport has no stable identity anchor.
+Transport session identity is the canonical continuity primitive for standards-compliant stateful MCP transports. For local `stdio` usage, the server-managed process session provides default continuity.
+
+Session identity and Octagon conversation identity are different concepts:
+
+- MCP session identity controls server-side continuity across tool calls
+- Octagon `conversation` controls the active Octagon thread inside that session
 
 The MCP result keeps the answer in `content`, and also returns structured metadata for orchestrators in `structuredContent`:
 
@@ -198,7 +205,7 @@ The MCP result keeps the answer in `content`, and also returns structured metada
 }
 ```
 
-Second-turn example:
+Explicit carry-forward example:
 
 ```json
 {
@@ -207,12 +214,12 @@ Second-turn example:
 }
 ```
 
-Thread-key example:
+New visible chat example:
 
 ```json
 {
-  "prompt": "AAPL",
-  "threadKey": "portfolio-chat-42"
+  "prompt": "Analyze Apple",
+  "newConversation": true
 }
 ```
 
@@ -221,10 +228,14 @@ Explicit refresh example:
 ```json
 {
   "prompt": "Start a fresh Octagon thread for this chat",
-  "threadKey": "portfolio-chat-42",
-  "resetConversation": true
+  "newConversation": true
 }
 ```
+
+**Stateful tool policy**
+
+- `octagon-agent`: stateful, uses a usable continuity anchor. In `stdio` hosts, that defaults to the server-managed process session unless you provide explicit `conversation`
+- other MCP tools: stateless and may run without session continuity
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ✅ Prediction market research tooling
 
-- `prediction-markets-agent` for Kalshi event research reports
+- `octagon-prediction-markets-agent` for Kalshi event research reports
 - `prediction_markets_history` for structured historical market data retrieval
 
 ## Get Your Octagon API Key
@@ -158,6 +158,73 @@ Orchestrates public and private market intelligence analysis.
 **Parameters**
 
 - `prompt` (string, required): natural language research request.
+- `conversation` (string, optional): existing Octagon conversation ID to continue a prior `octagon-agent` thread. Omit this on the first turn.
+- `threadKey` (string, optional): logical visible chat/thread identifier used for safe automatic conversation reuse when the MCP transport does not provide a stable session id.
+- `resetConversation` (boolean, optional): if `true`, clears the stored Octagon thread for the active session/thread anchor before making the request.
+
+**Threaded usage**
+
+`octagon-agent` is the only MCP tool that forwards Octagon conversation threading. The MCP resolves thread state in this order:
+
+1. explicit `conversation`
+2. stored conversation for the MCP `sessionId`
+3. stored conversation for `threadKey`
+4. otherwise no reuse; Octagon starts a fresh conversation
+
+This means you can use any of these patterns:
+
+1. First call: send only `prompt`
+2. Read `structuredContent.conversation` from the MCP result
+3. Second call: either
+   - send the new `prompt` plus that `conversation`, or
+   - keep the same MCP session, or
+   - send the same `threadKey`
+
+When both `sessionId` and `threadKey` are absent, the MCP does **not** auto-reuse a prior conversation. This avoids cross-chat leakage when the transport has no stable identity anchor.
+
+The MCP result keeps the answer in `content`, and also returns structured metadata for orchestrators in `structuredContent`:
+
+```json
+{
+  "model": "octagon-agent",
+  "text": "Which stock would you like the latest price for?",
+  "conversation": "conv_123",
+  "responseId": "resp_123",
+  "followUp": {
+    "required": true,
+    "inputTemplate": "<ticker or company name>",
+    "instructions": "Reply with just the missing detail and reuse the conversation value from this response."
+  }
+}
+```
+
+Second-turn example:
+
+```json
+{
+  "prompt": "AAPL",
+  "conversation": "conv_123"
+}
+```
+
+Thread-key example:
+
+```json
+{
+  "prompt": "AAPL",
+  "threadKey": "portfolio-chat-42"
+}
+```
+
+Explicit refresh example:
+
+```json
+{
+  "prompt": "Start a fresh Octagon thread for this chat",
+  "threadKey": "portfolio-chat-42",
+  "resetConversation": true
+}
+```
 
 Example:
 
@@ -195,7 +262,7 @@ More examples:
 - "Retrieve historical Bitcoin price data from 2023 and analyze the price volatility trends"
 - "Analyze the competitive dynamics in the EV charging infrastructure market"
 
-### `prediction-markets-agent`
+### `octagon-prediction-markets-agent`
 
 Generates research reports for Kalshi prediction market events.
 

--- a/examples/typescript-client-example.ts
+++ b/examples/typescript-client-example.ts
@@ -25,11 +25,13 @@ async function main() {
       console.log(`- ${tool.name}: ${tool.description}`);
     }
 
-    // Example: Query comprehensive market intelligence
+    // Example: Query comprehensive market intelligence.
+    // Mark the first turn of a new visible chat with newConversation.
     console.log("\nQuerying comprehensive market intelligence for Apple...");
     const marketResult = await client.callTool({
       name: "octagon-agent",
       arguments: {
+        newConversation: true,
         prompt: "Analyze Apple's latest 10-K filing and extract key financial metrics and risk factors",
       },
     });
@@ -39,18 +41,29 @@ async function main() {
     const conversationId = (marketResult as any).structuredContent?.conversation;
     console.log("Conversation ID:", conversationId);
 
+    console.log("\nContinuing the same octagon-agent session...");
+    const followUpResult = await client.callTool({
+      name: "octagon-agent",
+      arguments: {
+        prompt: "Now compare those risk factors to Microsoft's latest filing",
+      },
+    });
+
+    console.log("Follow-up Result:");
+    console.log((followUpResult as any).content[0].text);
+
     if (conversationId) {
-      console.log("\nContinuing the same octagon-agent thread...");
-      const followUpResult = await client.callTool({
+      console.log("\nBranching with an explicit conversation override...");
+      const branchResult = await client.callTool({
         name: "octagon-agent",
         arguments: {
-          prompt: "Now compare those risk factors to Microsoft's latest filing",
+          prompt: "Only summarize the most material Apple-specific risks again",
           conversation: conversationId,
         },
       });
 
-      console.log("Follow-up Result:");
-      console.log((followUpResult as any).content[0].text);
+      console.log("Explicit Conversation Result:");
+      console.log((branchResult as any).content[0].text);
     }
 
     // Example: Deep research analysis

--- a/examples/typescript-client-example.ts
+++ b/examples/typescript-client-example.ts
@@ -36,6 +36,22 @@ async function main() {
 
     console.log("Market Intelligence Result:");
     console.log((marketResult as any).content[0].text);
+    const conversationId = (marketResult as any).structuredContent?.conversation;
+    console.log("Conversation ID:", conversationId);
+
+    if (conversationId) {
+      console.log("\nContinuing the same octagon-agent thread...");
+      const followUpResult = await client.callTool({
+        name: "octagon-agent",
+        arguments: {
+          prompt: "Now compare those risk factors to Microsoft's latest filing",
+          conversation: conversationId,
+        },
+      });
+
+      console.log("Follow-up Result:");
+      console.log((followUpResult as any).content[0].text);
+    }
 
     // Example: Deep research analysis
     console.log("\nPerforming deep research on AI market trends...");
@@ -49,17 +65,18 @@ async function main() {
     console.log("Deep Research Analysis:");
     console.log((researchResult as any).content[0].text);
 
-    // Example: Web scraping
-    console.log("\nExtracting data from a website...");
-    const scrapingResult = await client.callTool({
-      name: "octagon-scraper-agent",
+    // Example: Prediction markets analysis
+    console.log("\nAnalyzing a Kalshi event...");
+    const predictionResult = await client.callTool({
+      name: "octagon-prediction-markets-agent",
       arguments: {
-        prompt: "Extract all data fields from zillow.com/san-francisco-ca/",
+        prompt:
+          "Generate a report for the Kalshi market https://kalshi.com/markets/kxbtcy/btc-price-range-eoy/kxbtcy-27jan0100",
       },
     });
 
-    console.log("Web Scraping Result:");
-    console.log((scrapingResult as any).content[0].text);
+    console.log("Prediction Markets Result:");
+    console.log((predictionResult as any).content[0].text);
 
     // Close the client
     await client.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octagon-mcp",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octagon-mcp",
-      "version": "1.0.15",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -124,7 +124,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -171,7 +170,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
       "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -693,7 +691,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -945,7 +942,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1586,7 +1582,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1662,7 +1657,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "prebuild": "node scripts/write-version.mjs",
     "build": "tsc && node -e \"require('fs').chmodSync('dist/index.js', '755')\"",
-    "test": "echo \"No tests specified\"",
+    "test": "npm run build && node --test tests/octagon-agent-threading.test.js",
     "start": "node dist/index.js",
     "lint": "echo \"No linting configured\"",
     "format": "echo \"No formatting configured\"",

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,4 +1,4 @@
-const DEFAULT_DEBUG_ENABLED = true;
+const DEFAULT_DEBUG_ENABLED = false;
 
 function parseBooleanFlag(
   value: string | undefined,

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,57 @@
+const DEFAULT_DEBUG_ENABLED = true;
+
+function parseBooleanFlag(
+  value: string | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "") {
+    return defaultValue;
+  }
+
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+}
+
+export const OCTAGON_MCP_DEBUG = parseBooleanFlag(
+  process.env.OCTAGON_MCP_DEBUG,
+  DEFAULT_DEBUG_ENABLED,
+);
+
+function safeSerialize(payload: unknown): string {
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  try {
+    return JSON.stringify(payload, null, 2);
+  } catch (error) {
+    return `<<unserializable payload: ${String(error)}>>`;
+  }
+}
+
+export function debugLog(label: string, payload?: unknown): void {
+  if (!OCTAGON_MCP_DEBUG) {
+    return;
+  }
+
+  if (payload === undefined) {
+    console.error(`[octagon-mcp][debug] ${label}`);
+    return;
+  }
+
+  console.error(
+    `[octagon-mcp][debug] ${label}\n${safeSerialize(payload)}`,
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ async function main() {
       packageName: PACKAGE_NAME,
       version: VERSION,
       debugEnabled: OCTAGON_MCP_DEBUG,
+      transportKind: "stdio",
     });
 
     registerMcpTools(server, octagonClient);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import createClient from "#client";
 import { registerMcpTools } from "#tools";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { OCTAGON_MCP_DEBUG, debugLog } from "./debug.js";
 import { VERSION } from "./version.js";
 
 const PACKAGE_NAME = "octagon-mcp";
@@ -23,6 +24,12 @@ async function main() {
       defaultHeaders: {
         "User-Agent": `${PACKAGE_NAME}/${VERSION} (Node.js/${process.versions.node})`,
       },
+    });
+
+    debugLog("MCP server starting", {
+      packageName: PACKAGE_NAME,
+      version: VERSION,
+      debugEnabled: OCTAGON_MCP_DEBUG,
     });
 
     registerMcpTools(server, octagonClient);

--- a/src/toolSessionState.ts
+++ b/src/toolSessionState.ts
@@ -1,85 +1,193 @@
 import { debugLog } from "./debug.js";
+import { randomUUID } from "node:crypto";
 
 export type ToolContext = {
   sessionId?: string;
-  threadKey?: string;
+  transportKind: "stdio" | "streamable_http" | "unknown";
+  signal?: AbortSignal;
 };
 
-type OctagonSessionState = {
-  conversation?: string;
-  responseId?: string;
+export type SessionExtra = {
+  sessionId?: string;
+  signal?: AbortSignal;
+  transportKind?: "stdio" | "streamable_http" | "unknown";
 };
 
-const octagonConversationBySession = new Map<string, OctagonSessionState>();
+export type SessionState = {
+  sessionId: string;
+  createdAt: string;
+  lastSeenAt: string;
+  activeConversationId?: string;
+  lastResponseId?: string;
+  activeTool?: string;
+};
 
-export type ThreadAnchor =
+const sessionStateByAnchor = new Map<string, SessionState>();
+
+export type SessionAnchor =
   | {
       key: string;
-      type: "session";
+      sessionId: string;
+      type: "transport_session";
     }
   | {
       key: string;
-      type: "thread_key";
+      sessionId: string;
+      type: "stdio_session";
     };
 
-export function resolveThreadAnchor(
+const DEFAULT_STDIO_SESSION_ID = `stdio:${randomUUID()}`;
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function nowIsoString(): string {
+  return new Date().toISOString();
+}
+
+export function normalizeToolContext(extra?: SessionExtra): ToolContext {
+  const normalizedTransportKind = extra?.transportKind ?? "stdio";
+  const normalizedSessionId =
+    asNonEmptyString(extra?.sessionId) ??
+    (normalizedTransportKind === "stdio" ? DEFAULT_STDIO_SESSION_ID : undefined);
+
+  return {
+    sessionId: normalizedSessionId,
+    transportKind: normalizedTransportKind,
+    signal: extra?.signal,
+  };
+}
+
+export function resolveSessionAnchor(
   context?: ToolContext,
-): ThreadAnchor | undefined {
-  if (context?.sessionId) {
+): SessionAnchor | undefined {
+  if (context?.transportKind !== "stdio" && context?.sessionId) {
     return {
       key: `session:${context.sessionId}`,
-      type: "session",
+      sessionId: context.sessionId,
+      type: "transport_session",
     };
   }
 
-  if (context?.threadKey) {
+  if (context?.transportKind === "stdio" && context?.sessionId) {
     return {
-      key: `thread:${context.threadKey}`,
-      type: "thread_key",
+      key: `session:${context.sessionId}`,
+      sessionId: context.sessionId,
+      type: "stdio_session",
     };
   }
 
   return undefined;
 }
 
-export function getStoredOctagonConversation(
+function upsertSessionState(
   context?: ToolContext,
-): OctagonSessionState | undefined {
-  const anchor = resolveThreadAnchor(context);
+  {
+    activeTool,
+    activeConversationId,
+    lastResponseId,
+  }: {
+    activeTool?: string;
+    activeConversationId?: string;
+    lastResponseId?: string;
+  } = {},
+): SessionState | undefined {
+  const anchor = resolveSessionAnchor(context);
   if (!anchor) {
     return undefined;
   }
 
-  return octagonConversationBySession.get(anchor.key);
+  const existing = sessionStateByAnchor.get(anchor.key);
+  const timestamp = nowIsoString();
+  const nextState: SessionState = {
+    sessionId: anchor.sessionId,
+    createdAt: existing?.createdAt ?? timestamp,
+    lastSeenAt: timestamp,
+    activeConversationId:
+      activeConversationId ?? existing?.activeConversationId,
+    lastResponseId: lastResponseId ?? existing?.lastResponseId,
+    activeTool: activeTool ?? existing?.activeTool,
+  };
+
+  sessionStateByAnchor.set(anchor.key, nextState);
+  return nextState;
 }
 
-export function storeOctagonConversation(
-  context: ToolContext | undefined,
-  value: OctagonSessionState,
-): void {
-  const anchor = resolveThreadAnchor(context);
+export function getSessionState(
+  context?: ToolContext,
+): SessionState | undefined {
+  const anchor = resolveSessionAnchor(context);
   if (!anchor) {
     return;
   }
 
-  octagonConversationBySession.set(anchor.key, value);
+  const existing = sessionStateByAnchor.get(anchor.key);
+  if (!existing) {
+    return undefined;
+  }
+
+  const touchedState: SessionState = {
+    ...existing,
+    lastSeenAt: nowIsoString(),
+  };
+  sessionStateByAnchor.set(anchor.key, touchedState);
+  return touchedState;
+}
+
+export function touchSession(
+  context?: ToolContext,
+  { activeTool }: { activeTool?: string } = {},
+): SessionState | undefined {
+  return upsertSessionState(context, {
+    activeTool,
+  });
+}
+
+export function storeOctagonConversation(
+  context: ToolContext | undefined,
+  value: {
+    conversation?: string;
+    responseId?: string;
+  },
+): SessionState | undefined {
+  return upsertSessionState(context, {
+    activeTool: "octagon-agent",
+    activeConversationId: value.conversation,
+    lastResponseId: value.responseId,
+  });
 }
 
 export function clearOctagonConversation(
   context?: ToolContext,
   reason?: string,
 ): void {
-  const anchor = resolveThreadAnchor(context);
+  const anchor = resolveSessionAnchor(context);
   if (!anchor) {
     return;
   }
 
-  const hadConversation = octagonConversationBySession.delete(anchor.key);
+  const existing = sessionStateByAnchor.get(anchor.key);
+  if (!existing) {
+    return;
+  }
+
+  const hadConversation = Boolean(
+    existing.activeConversationId || existing.lastResponseId,
+  );
+
+  const nextState: SessionState = {
+    ...existing,
+    lastSeenAt: nowIsoString(),
+    activeConversationId: undefined,
+    lastResponseId: undefined,
+  };
+  sessionStateByAnchor.set(anchor.key, nextState);
 
   if (hadConversation) {
     debugLog("octagon-agent session conversation cleared", {
       sessionId: context?.sessionId ?? null,
-      threadKey: context?.threadKey ?? null,
+      transportKind: context?.transportKind ?? "unknown",
       anchorType: anchor.type,
       anchorKey: anchor.key,
       reason: reason ?? "unspecified",
@@ -87,13 +195,49 @@ export function clearOctagonConversation(
   }
 }
 
+export function terminateSession(
+  context?: ToolContext,
+  reason?: string,
+): void {
+  const anchor = resolveSessionAnchor(context);
+  if (!anchor) {
+    return;
+  }
+
+  const existing = sessionStateByAnchor.get(anchor.key);
+  if (!existing) {
+    return;
+  }
+
+  sessionStateByAnchor.delete(anchor.key);
+  debugLog("mcp session terminated", {
+    sessionId: context?.sessionId ?? null,
+    transportKind: context?.transportKind ?? "unknown",
+    anchorType: anchor.type,
+    anchorKey: anchor.key,
+    activeTool: existing.activeTool ?? null,
+    activeConversationId: existing.activeConversationId ?? null,
+    reason: reason ?? "unspecified",
+  });
+}
+
 export function clearOctagonConversationForToolChange(
   context: ToolContext | undefined,
   toolName: string,
 ): void {
+  touchSession(context, { activeTool: toolName });
+
   if (toolName === "octagon-agent") {
     return;
   }
 
   clearOctagonConversation(context, `tool_changed:${toolName}`);
+}
+
+export function resetSessionStateForTests(): void {
+  sessionStateByAnchor.clear();
+}
+
+export function getDefaultStdioSessionIdForTests(): string {
+  return DEFAULT_STDIO_SESSION_ID;
 }

--- a/src/toolSessionState.ts
+++ b/src/toolSessionState.ts
@@ -1,0 +1,99 @@
+import { debugLog } from "./debug.js";
+
+export type ToolContext = {
+  sessionId?: string;
+  threadKey?: string;
+};
+
+type OctagonSessionState = {
+  conversation?: string;
+  responseId?: string;
+};
+
+const octagonConversationBySession = new Map<string, OctagonSessionState>();
+
+export type ThreadAnchor =
+  | {
+      key: string;
+      type: "session";
+    }
+  | {
+      key: string;
+      type: "thread_key";
+    };
+
+export function resolveThreadAnchor(
+  context?: ToolContext,
+): ThreadAnchor | undefined {
+  if (context?.sessionId) {
+    return {
+      key: `session:${context.sessionId}`,
+      type: "session",
+    };
+  }
+
+  if (context?.threadKey) {
+    return {
+      key: `thread:${context.threadKey}`,
+      type: "thread_key",
+    };
+  }
+
+  return undefined;
+}
+
+export function getStoredOctagonConversation(
+  context?: ToolContext,
+): OctagonSessionState | undefined {
+  const anchor = resolveThreadAnchor(context);
+  if (!anchor) {
+    return undefined;
+  }
+
+  return octagonConversationBySession.get(anchor.key);
+}
+
+export function storeOctagonConversation(
+  context: ToolContext | undefined,
+  value: OctagonSessionState,
+): void {
+  const anchor = resolveThreadAnchor(context);
+  if (!anchor) {
+    return;
+  }
+
+  octagonConversationBySession.set(anchor.key, value);
+}
+
+export function clearOctagonConversation(
+  context?: ToolContext,
+  reason?: string,
+): void {
+  const anchor = resolveThreadAnchor(context);
+  if (!anchor) {
+    return;
+  }
+
+  const hadConversation = octagonConversationBySession.delete(anchor.key);
+
+  if (hadConversation) {
+    debugLog("octagon-agent session conversation cleared", {
+      sessionId: context?.sessionId ?? null,
+      threadKey: context?.threadKey ?? null,
+      anchorType: anchor.type,
+      anchorKey: anchor.key,
+      reason: reason ?? "unspecified",
+    });
+  }
+}
+
+export function clearOctagonConversationForToolChange(
+  context: ToolContext | undefined,
+  toolName: string,
+): void {
+  if (toolName === "octagon-agent") {
+    return;
+  }
+
+  clearOctagonConversation(context, `tool_changed:${toolName}`);
+}

--- a/src/toolSessionState.ts
+++ b/src/toolSessionState.ts
@@ -135,15 +135,6 @@ export function getSessionState(
   return touchedState;
 }
 
-export function touchSession(
-  context?: ToolContext,
-  { activeTool }: { activeTool?: string } = {},
-): SessionState | undefined {
-  return upsertSessionState(context, {
-    activeTool,
-  });
-}
-
 export function storeOctagonConversation(
   context: ToolContext | undefined,
   value: {
@@ -219,19 +210,6 @@ export function terminateSession(
     activeConversationId: existing.activeConversationId ?? null,
     reason: reason ?? "unspecified",
   });
-}
-
-export function clearOctagonConversationForToolChange(
-  context: ToolContext | undefined,
-  toolName: string,
-): void {
-  touchSession(context, { activeTool: toolName });
-
-  if (toolName === "octagon-agent") {
-    return;
-  }
-
-  clearOctagonConversation(context, `tool_changed:${toolName}`);
 }
 
 export function resetSessionStateForTests(): void {

--- a/src/tools/deepResearchAgent.ts
+++ b/src/tools/deepResearchAgent.ts
@@ -2,7 +2,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
 
-import { clearOctagonConversationForToolChange } from "../toolSessionState.js";
+import {
+  clearOctagonConversationForToolChange,
+  normalizeToolContext,
+  type SessionExtra,
+} from "../toolSessionState.js";
 import { createStreamingTextResponse, createTextErrorResult } from "#tools/shared";
 
 const AGENT_NAME = "octagon-deep-research-agent";
@@ -21,17 +25,13 @@ type Params = {
   prompt: string;
 };
 
-type ToolExtra = {
-  sessionId?: string;
-};
-
 export async function executeDeepResearchTool(
   client: OpenAI,
   { prompt }: Params,
-  extra?: ToolExtra,
+  extra?: SessionExtra,
 ) {
   try {
-    clearOctagonConversationForToolChange(extra, AGENT_NAME);
+    clearOctagonConversationForToolChange(normalizeToolContext(extra), AGENT_NAME);
     const result = await createStreamingTextResponse(client, AGENT_NAME, prompt);
     return {
       content: [{ type: "text" as const, text: result }],
@@ -50,7 +50,7 @@ export function registerTool(server: McpServer, client: OpenAI): void {
       name: string,
       description: string,
       inputSchema: Record<string, z.ZodTypeAny>,
-      callback: (args: Params, extra?: ToolExtra) => Promise<unknown>,
+      callback: (args: Params, extra?: SessionExtra) => Promise<unknown>,
     ) => unknown;
   };
 

--- a/src/tools/deepResearchAgent.ts
+++ b/src/tools/deepResearchAgent.ts
@@ -2,11 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
 
-import {
-  clearOctagonConversationForToolChange,
-  normalizeToolContext,
-  type SessionExtra,
-} from "../toolSessionState.js";
+import { type SessionExtra } from "../toolSessionState.js";
 import { createStreamingTextResponse, createTextErrorResult } from "#tools/shared";
 
 const AGENT_NAME = "octagon-deep-research-agent";
@@ -31,7 +27,6 @@ export async function executeDeepResearchTool(
   extra?: SessionExtra,
 ) {
   try {
-    clearOctagonConversationForToolChange(normalizeToolContext(extra), AGENT_NAME);
     const result = await createStreamingTextResponse(client, AGENT_NAME, prompt);
     return {
       content: [{ type: "text" as const, text: result }],

--- a/src/tools/deepResearchAgent.ts
+++ b/src/tools/deepResearchAgent.ts
@@ -2,45 +2,62 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
 
-import { createResponse } from "#tools/shared";
+import { clearOctagonConversationForToolChange } from "../toolSessionState.js";
+import { createStreamingTextResponse, createTextErrorResult } from "#tools/shared";
 
 const AGENT_NAME = "octagon-deep-research-agent";
 const AGENT_DESCRIPTION =
   "A comprehensive agent that can utilize multiple sources for deep research analysis. Capabilities: Aggregate research across multiple data sources, synthesize information, and provide comprehensive investment research. Best for: Investment research questions requiring up-to-date aggregated information from the web.";
 
-const INPUT_SCHEMA = {
+const deepResearchInputShape = {
   prompt: z
     .string()
     .describe("Your natural language query or request for the agent"),
 };
 
+export const deepResearchInputSchema = z.object(deepResearchInputShape).strict();
+
 type Params = {
   prompt: string;
 };
 
+type ToolExtra = {
+  sessionId?: string;
+};
+
+export async function executeDeepResearchTool(
+  client: OpenAI,
+  { prompt }: Params,
+  extra?: ToolExtra,
+) {
+  try {
+    clearOctagonConversationForToolChange(extra, AGENT_NAME);
+    const result = await createStreamingTextResponse(client, AGENT_NAME, prompt);
+    return {
+      content: [{ type: "text" as const, text: result }],
+    };
+  } catch (error) {
+    console.error("Error calling Deep Research agent:", error);
+    return createTextErrorResult(
+      "Error: Failed to process deep research query.",
+    );
+  }
+}
+
 export function registerTool(server: McpServer, client: OpenAI): void {
-  (server as any).tool(
+  const toolServer = server as unknown as {
+    tool: (
+      name: string,
+      description: string,
+      inputSchema: Record<string, z.ZodTypeAny>,
+      callback: (args: Params, extra?: ToolExtra) => Promise<unknown>,
+    ) => unknown;
+  };
+
+  toolServer.tool(
     AGENT_NAME,
     AGENT_DESCRIPTION,
-    INPUT_SCHEMA,
-    async ({ prompt }: Params) => {
-      try {
-        const result = await createResponse(client, AGENT_NAME, prompt);
-        return {
-          content: [{ type: "text", text: result }],
-        };
-      } catch (error) {
-        console.error("Error calling Deep Research agent:", error);
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "Error: Failed to process deep research query.",
-            },
-          ],
-        };
-      }
-    },
+    deepResearchInputShape,
+    async (args, extra) => executeDeepResearchTool(client, args, extra),
   );
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,13 +2,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 
 import { registerTool as registerDeepResearchTool } from "#tools/deepResearchAgent";
-import { registerTool as registerStockDataTool } from "#tools/octagonAgent";
+import { registerTool as registerOctagonAgentTool } from "#tools/octagonAgent";
 import { registerTool as registerPredictionMarketsTool } from "#tools/predictionMarketsAgent";
 import { registerTool as registerPredictionMarketsHistoryTool } from "#tools/predictionMarketsHistory";
 
 export function registerMcpTools(server: McpServer, client: OpenAI): void {
   registerDeepResearchTool(server, client);
-  registerStockDataTool(server, client);
+  registerOctagonAgentTool(server, client);
   registerPredictionMarketsTool(server, client);
   registerPredictionMarketsHistoryTool(server, client);
 }

--- a/src/tools/octagonAgent.ts
+++ b/src/tools/octagonAgent.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 import { debugLog } from "../debug.js";
 import {
   clearOctagonConversation,
-  getStoredOctagonConversation,
-  resolveThreadAnchor,
+  getSessionState,
+  normalizeToolContext,
+  resolveSessionAnchor,
   storeOctagonConversation,
-  type ToolContext,
+  type SessionExtra,
 } from "../toolSessionState.js";
 import { createOctagonAgentResponse, createTextErrorResult } from "#tools/shared";
 
@@ -26,17 +27,11 @@ const octagonAgentInputShape = {
     .describe(
       "Existing Octagon conversation ID to continue a prior octagon-agent thread. Omit on the first turn.",
     ),
-  threadKey: z
-    .string()
-    .optional()
-    .describe(
-      "Logical visible chat/thread identifier to reuse octagon-agent conversation when MCP transport does not provide a session id.",
-    ),
-  resetConversation: z
+  newConversation: z
     .boolean()
     .optional()
     .describe(
-      "If true, drop any stored octagon-agent thread for the active session/thread anchor before processing the request.",
+      "If true, start a fresh Octagon conversation for the active session. Top-layer agents should pass this on the first turn of a new user chat.",
     ),
 };
 
@@ -64,54 +59,106 @@ export const octagonAgentOutputSchema = z.object({
 type Params = {
   prompt: string;
   conversation?: string;
-  threadKey?: string;
-  resetConversation?: boolean;
+  newConversation?: boolean;
 };
+
+const CONFLICTING_CONTINUATION_ERROR =
+  "Error: octagon-agent request cannot include both conversation and newConversation. Use conversation to continue an existing thread, or newConversation to start a fresh one.";
+const MISSING_SESSION_ERROR =
+  "Error: octagon-agent requires session continuity. Provide MCP transport session identity, rely on the stdio session, or explicitly continue with conversation.";
 
 export async function executeOctagonAgentTool(
   client: OpenAI,
-  { prompt, conversation, threadKey, resetConversation }: Params,
-  extra?: ToolContext,
+  { prompt, conversation, newConversation }: Params,
+  extra?: SessionExtra,
 ) {
   try {
-    const threadContext = {
-      sessionId: extra?.sessionId,
-      threadKey,
-    };
-    const threadAnchor = resolveThreadAnchor(threadContext);
-    const storedThreadState = getStoredOctagonConversation(threadContext);
-    const storedConversation = storedThreadState?.conversation;
+    const sessionContext = normalizeToolContext(extra);
+    const sessionAnchor = resolveSessionAnchor(sessionContext);
+    const storedSessionState = getSessionState(sessionContext);
+    const storedConversation = storedSessionState?.activeConversationId;
+    const effectiveReset = Boolean(newConversation);
+    const resetReason = newConversation ? "new_conversation_request" : null;
 
-    if (resetConversation) {
-      clearOctagonConversation(threadContext, "explicit_reset");
+    if (conversation && newConversation) {
+      debugLog("octagon-agent conflicting continuation arguments", {
+        prompt,
+        promptLength: prompt.length,
+        transportKind: sessionContext.transportKind,
+        sessionId: sessionContext.sessionId ?? null,
+        providedConversation: conversation,
+        newConversation: true,
+      });
+      return createTextErrorResult(CONFLICTING_CONTINUATION_ERROR);
+    }
+
+    if (!sessionAnchor && !conversation) {
+      debugLog("octagon-agent missing required session continuity", {
+        prompt,
+        promptLength: prompt.length,
+        transportKind: sessionContext.transportKind,
+        sessionId: sessionContext.sessionId ?? null,
+        anchorType: "none",
+        providedConversation: null,
+        storedConversation: null,
+        resolvedConversation: null,
+        hasConversation: false,
+        newConversation: Boolean(newConversation),
+        sessionResetApplied: false,
+        resetReason,
+        conversationSource: "new",
+        sessionRequired: true,
+        reuseBlockedReason:
+          sessionContext.transportKind === "stdio"
+            ? "missing_stdio_session"
+            : "missing_required_session_anchor",
+      });
+      return createTextErrorResult(MISSING_SESSION_ERROR);
+    }
+
+    if (effectiveReset) {
+      clearOctagonConversation(sessionContext, resetReason ?? "explicit_reset");
     }
 
     const resolvedConversation =
       conversation ??
-      (resetConversation ? undefined : storedConversation);
+      (effectiveReset ? undefined : storedConversation);
     const anchorType = conversation
       ? "provided_conversation"
-      : threadAnchor?.type ?? "none";
+      : sessionAnchor?.type ?? "none";
     const conversationSource = conversation
       ? "provided"
-      : resolvedConversation && threadAnchor?.type === "session"
-        ? "stored_session"
-        : resolvedConversation && threadAnchor?.type === "thread_key"
-          ? "stored_thread_key"
+      : resolvedConversation && sessionAnchor?.type === "transport_session"
+        ? "stored_transport_session"
+        : resolvedConversation && sessionAnchor?.type === "stdio_session"
+          ? "stored_stdio_session"
           : "new";
+    const sessionSource = sessionAnchor?.type ?? "none";
+    const sessionStateId = storedSessionState?.sessionId ?? sessionAnchor?.sessionId;
 
     debugLog("octagon-agent inbound MCP request", {
       prompt,
       promptLength: prompt.length,
-      sessionId: extra?.sessionId ?? null,
-      threadKey: threadKey ?? null,
+      transportKind: sessionContext.transportKind,
+      sessionId: sessionContext.sessionId ?? null,
+      sessionSource,
+      sessionStateId: sessionStateId ?? null,
       anchorType,
       providedConversation: conversation ?? null,
       storedConversation: storedConversation ?? null,
       resolvedConversation: resolvedConversation ?? null,
       hasConversation: Boolean(resolvedConversation),
-      resetConversation: Boolean(resetConversation),
+      newConversation: Boolean(newConversation),
+      sessionResetApplied: effectiveReset,
+      resetReason,
       conversationSource,
+      sessionRequired: !conversation,
+      reuseBlockedReason:
+        !sessionAnchor && !conversation
+          ? sessionContext.transportKind === "stdio"
+            ? "missing_stdio_session"
+            : "missing_required_session_anchor"
+          : null,
     });
 
     const result = await createOctagonAgentResponse(client, {
@@ -120,7 +167,7 @@ export async function executeOctagonAgentTool(
     });
 
     if (result.conversation) {
-      storeOctagonConversation(threadContext, {
+      storeOctagonConversation(sessionContext, {
         conversation: result.conversation,
         responseId: result.responseId,
       });
@@ -131,7 +178,14 @@ export async function executeOctagonAgentTool(
       structuredContent: result,
     };
 
-    debugLog("octagon-agent outbound MCP tool result", toolResult);
+    debugLog("octagon-agent outbound MCP tool result", {
+      model: result.model,
+      conversation: result.conversation ?? null,
+      responseId: result.responseId ?? null,
+      textLength: result.text.length,
+      hasFollowUp: Boolean(result.followUp),
+      metadataKeys: result.rawMetadata ? Object.keys(result.rawMetadata) : [],
+    });
 
     return toolResult;
   } catch (error) {
@@ -148,7 +202,7 @@ export function registerTool(server: McpServer, client: OpenAI): void {
       name: string,
       description: string,
       inputSchema: Record<string, z.ZodTypeAny>,
-      callback: (args: Params, extra?: ToolContext) => Promise<unknown>,
+      callback: (args: Params, extra?: SessionExtra) => Promise<unknown>,
     ) => unknown;
   };
 
@@ -157,12 +211,12 @@ export function registerTool(server: McpServer, client: OpenAI): void {
     AGENT_DESCRIPTION,
     octagonAgentInputShape,
     async (
-      { prompt, conversation, threadKey, resetConversation }: Params,
-      extra?: ToolContext,
+      { prompt, conversation, newConversation }: Params,
+      extra?: SessionExtra,
     ) =>
       executeOctagonAgentTool(
         client,
-        { prompt, conversation, threadKey, resetConversation },
+        { prompt, conversation, newConversation },
         extra,
       ),
   );

--- a/src/tools/octagonAgent.ts
+++ b/src/tools/octagonAgent.ts
@@ -2,45 +2,168 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
 
-import { createResponse } from "#tools/shared";
+import { debugLog } from "../debug.js";
+import {
+  clearOctagonConversation,
+  getStoredOctagonConversation,
+  resolveThreadAnchor,
+  storeOctagonConversation,
+  type ToolContext,
+} from "../toolSessionState.js";
+import { createOctagonAgentResponse, createTextErrorResult } from "#tools/shared";
 
 const AGENT_NAME = "octagon-agent";
 const AGENT_DESCRIPTION =
   "Orchestrates all agents for comprehensive market intelligence analysis. Capabilities: Combines insights from SEC filings, earnings calls, financial metrics, stock data, institutional holdings, private company research, funding analysis, M&A transactions, investor intelligence, and debt analysis to provide holistic market intelligence. Best for: Complex research requiring multiple data sources and comprehensive analysis across public and private markets.";
 
-const INPUT_SCHEMA = {
+const octagonAgentInputShape = {
   prompt: z
     .string()
     .describe("Your natural language query or request for the agent"),
+  conversation: z
+    .string()
+    .optional()
+    .describe(
+      "Existing Octagon conversation ID to continue a prior octagon-agent thread. Omit on the first turn.",
+    ),
+  threadKey: z
+    .string()
+    .optional()
+    .describe(
+      "Logical visible chat/thread identifier to reuse octagon-agent conversation when MCP transport does not provide a session id.",
+    ),
+  resetConversation: z
+    .boolean()
+    .optional()
+    .describe(
+      "If true, drop any stored octagon-agent thread for the active session/thread anchor before processing the request.",
+    ),
 };
+
+export const octagonAgentInputSchema = z.object(octagonAgentInputShape).strict();
+
+export const octagonAgentOutputSchema = z.object({
+  model: z.literal(AGENT_NAME),
+  text: z.string(),
+  conversation: z.string().optional(),
+  responseId: z.string().optional(),
+  followUp: z
+    .object({
+      required: z.boolean(),
+      instructions: z.string().optional(),
+      inputTemplate: z.string().optional(),
+      exampleRequest: z.string().optional(),
+      missingIdentifier: z.string().optional(),
+      reason: z.string().optional(),
+      source: z.string().optional(),
+    })
+    .optional(),
+  rawMetadata: z.record(z.string()).optional(),
+});
 
 type Params = {
   prompt: string;
+  conversation?: string;
+  threadKey?: string;
+  resetConversation?: boolean;
 };
 
+export async function executeOctagonAgentTool(
+  client: OpenAI,
+  { prompt, conversation, threadKey, resetConversation }: Params,
+  extra?: ToolContext,
+) {
+  try {
+    const threadContext = {
+      sessionId: extra?.sessionId,
+      threadKey,
+    };
+    const threadAnchor = resolveThreadAnchor(threadContext);
+    const storedThreadState = getStoredOctagonConversation(threadContext);
+    const storedConversation = storedThreadState?.conversation;
+
+    if (resetConversation) {
+      clearOctagonConversation(threadContext, "explicit_reset");
+    }
+
+    const resolvedConversation =
+      conversation ??
+      (resetConversation ? undefined : storedConversation);
+    const anchorType = conversation
+      ? "provided_conversation"
+      : threadAnchor?.type ?? "none";
+    const conversationSource = conversation
+      ? "provided"
+      : resolvedConversation && threadAnchor?.type === "session"
+        ? "stored_session"
+        : resolvedConversation && threadAnchor?.type === "thread_key"
+          ? "stored_thread_key"
+          : "new";
+
+    debugLog("octagon-agent inbound MCP request", {
+      prompt,
+      promptLength: prompt.length,
+      sessionId: extra?.sessionId ?? null,
+      threadKey: threadKey ?? null,
+      anchorType,
+      providedConversation: conversation ?? null,
+      storedConversation: storedConversation ?? null,
+      resolvedConversation: resolvedConversation ?? null,
+      hasConversation: Boolean(resolvedConversation),
+      resetConversation: Boolean(resetConversation),
+      conversationSource,
+    });
+
+    const result = await createOctagonAgentResponse(client, {
+      prompt,
+      conversation: resolvedConversation,
+    });
+
+    if (result.conversation) {
+      storeOctagonConversation(threadContext, {
+        conversation: result.conversation,
+        responseId: result.responseId,
+      });
+    }
+
+    const toolResult = {
+      content: [{ type: "text" as const, text: result.text }],
+      structuredContent: result,
+    };
+
+    debugLog("octagon-agent outbound MCP tool result", toolResult);
+
+    return toolResult;
+  } catch (error) {
+    console.error("Error calling Octagon agent:", error);
+    return createTextErrorResult(
+      "Error: Failed to process Octagon agent query.",
+    );
+  }
+}
+
 export function registerTool(server: McpServer, client: OpenAI): void {
-  (server as any).tool(
+  const toolServer = server as unknown as {
+    tool: (
+      name: string,
+      description: string,
+      inputSchema: Record<string, z.ZodTypeAny>,
+      callback: (args: Params, extra?: ToolContext) => Promise<unknown>,
+    ) => unknown;
+  };
+
+  toolServer.tool(
     AGENT_NAME,
     AGENT_DESCRIPTION,
-    INPUT_SCHEMA,
-    async ({ prompt }: Params) => {
-      try {
-        const result = await createResponse(client, AGENT_NAME, prompt);
-        return {
-          content: [{ type: "text", text: result }],
-        };
-      } catch (error) {
-        console.error("Error calling Octagon agent:", error);
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "Error: Failed to process Octagon agent query.",
-            },
-          ],
-        };
-      }
-    },
+    octagonAgentInputShape,
+    async (
+      { prompt, conversation, threadKey, resetConversation }: Params,
+      extra?: ToolContext,
+    ) =>
+      executeOctagonAgentTool(
+        client,
+        { prompt, conversation, threadKey, resetConversation },
+        extra,
+      ),
   );
 }

--- a/src/tools/predictionMarketsAgent.ts
+++ b/src/tools/predictionMarketsAgent.ts
@@ -2,7 +2,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
 
-import { clearOctagonConversationForToolChange } from "../toolSessionState.js";
+import {
+  clearOctagonConversationForToolChange,
+  normalizeToolContext,
+  type SessionExtra,
+} from "../toolSessionState.js";
 import { createStreamingTextResponse, createTextErrorResult } from "#tools/shared";
 
 const AGENT_NAME = "octagon-prediction-markets-agent";
@@ -25,14 +29,10 @@ type Params = {
   cache: boolean | undefined;
 };
 
-type ToolExtra = {
-  sessionId?: string;
-};
-
 export async function executePredictionMarketsTool(
   client: OpenAI,
   { prompt, cache }: Params,
-  extra?: ToolExtra,
+  extra?: SessionExtra,
 ) {
   let model;
   if (cache === undefined) {
@@ -44,7 +44,7 @@ export async function executePredictionMarketsTool(
   }
 
   try {
-    clearOctagonConversationForToolChange(extra, AGENT_NAME);
+    clearOctagonConversationForToolChange(normalizeToolContext(extra), AGENT_NAME);
     const result = await createStreamingTextResponse(client, model, prompt);
     return {
       content: [{ type: "text" as const, text: result }],
@@ -63,7 +63,7 @@ export function registerTool(server: McpServer, client: OpenAI): void {
       name: string,
       description: string,
       inputSchema: Record<string, z.ZodTypeAny>,
-      callback: (args: Params, extra?: ToolExtra) => Promise<unknown>,
+      callback: (args: Params, extra?: SessionExtra) => Promise<unknown>,
     ) => unknown;
   };
 

--- a/src/tools/predictionMarketsAgent.ts
+++ b/src/tools/predictionMarketsAgent.ts
@@ -2,57 +2,75 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
 
-import { createResponse } from "#tools/shared";
+import { clearOctagonConversationForToolChange } from "../toolSessionState.js";
+import { createStreamingTextResponse, createTextErrorResult } from "#tools/shared";
 
 const AGENT_NAME = "octagon-prediction-markets-agent";
 const AGENT_DESCRIPTION =
   "A specialized agent for creating research reports on Kalshi events. See what's driving prices, compare market vs model probabilities, and find potential mispricings.";
 
-const INPUT_SCHEMA = {
+const predictionMarketsInputShape = {
   prompt: z
     .string()
     .describe("Your natural language query or request for the agent"),
   cache: z.boolean().optional().describe("Whether to cache the response"),
 };
 
+export const predictionMarketsInputSchema = z
+  .object(predictionMarketsInputShape)
+  .strict();
+
 type Params = {
   prompt: string;
   cache: boolean | undefined;
 };
 
+type ToolExtra = {
+  sessionId?: string;
+};
+
+export async function executePredictionMarketsTool(
+  client: OpenAI,
+  { prompt, cache }: Params,
+  extra?: ToolExtra,
+) {
+  let model;
+  if (cache === undefined) {
+    model = AGENT_NAME;
+  } else if (cache === false) {
+    model = `${AGENT_NAME}:refresh`;
+  } else {
+    model = `${AGENT_NAME}:cache`;
+  }
+
+  try {
+    clearOctagonConversationForToolChange(extra, AGENT_NAME);
+    const result = await createStreamingTextResponse(client, model, prompt);
+    return {
+      content: [{ type: "text" as const, text: result }],
+    };
+  } catch (error) {
+    console.error(`Error calling ${model}:`, error);
+    return createTextErrorResult(
+      "Error: Failed to process prediction markets query.",
+    );
+  }
+}
+
 export function registerTool(server: McpServer, client: OpenAI): void {
-  (server as any).tool(
+  const toolServer = server as unknown as {
+    tool: (
+      name: string,
+      description: string,
+      inputSchema: Record<string, z.ZodTypeAny>,
+      callback: (args: Params, extra?: ToolExtra) => Promise<unknown>,
+    ) => unknown;
+  };
+
+  toolServer.tool(
     AGENT_NAME,
     AGENT_DESCRIPTION,
-    INPUT_SCHEMA,
-    async ({ prompt, cache }: Params) => {
-      // Resolve the model variant based on the cache flag
-      let model;
-      if (cache === undefined) {
-        model = AGENT_NAME;
-      } else if (cache !== undefined && cache === false) {
-        model = `${AGENT_NAME}:refresh`;
-      } else {
-        model = `${AGENT_NAME}:cache`;
-      }
-
-      try {
-        const result = await createResponse(client, model, prompt);
-        return {
-          content: [{ type: "text", text: result }],
-        };
-      } catch (error) {
-        console.error(`Error calling ${model}:`, error);
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "Error: Failed to process prediction markets query.",
-            },
-          ],
-        };
-      }
-    },
+    predictionMarketsInputShape,
+    async (args, extra) => executePredictionMarketsTool(client, args, extra),
   );
 }

--- a/src/tools/predictionMarketsAgent.ts
+++ b/src/tools/predictionMarketsAgent.ts
@@ -2,11 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
 
-import {
-  clearOctagonConversationForToolChange,
-  normalizeToolContext,
-  type SessionExtra,
-} from "../toolSessionState.js";
+import { type SessionExtra } from "../toolSessionState.js";
 import { createStreamingTextResponse, createTextErrorResult } from "#tools/shared";
 
 const AGENT_NAME = "octagon-prediction-markets-agent";
@@ -44,7 +40,6 @@ export async function executePredictionMarketsTool(
   }
 
   try {
-    clearOctagonConversationForToolChange(normalizeToolContext(extra), AGENT_NAME);
     const result = await createStreamingTextResponse(client, model, prompt);
     return {
       content: [{ type: "text" as const, text: result }],

--- a/src/tools/predictionMarketsHistory.ts
+++ b/src/tools/predictionMarketsHistory.ts
@@ -2,11 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI, { APIError } from "openai";
 import { z } from "zod";
 
-import {
-  clearOctagonConversationForToolChange,
-  normalizeToolContext,
-  type SessionExtra,
-} from "../toolSessionState.js";
+import { type SessionExtra } from "../toolSessionState.js";
 
 const TOOL_NAME = "prediction_markets_history";
 const TOOL_DESCRIPTION = `Fetch historical data for a prediction market event by ticker.
@@ -69,7 +65,6 @@ export async function executePredictionMarketsHistoryTool(
   extra?: SessionExtra,
 ) {
   try {
-    clearOctagonConversationForToolChange(normalizeToolContext(extra), TOOL_NAME);
     const eventTicker = encodeURIComponent(params.event_ticker.trim());
 
     const query: Record<string, string | number> = {};

--- a/src/tools/predictionMarketsHistory.ts
+++ b/src/tools/predictionMarketsHistory.ts
@@ -2,6 +2,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI, { APIError } from "openai";
 import { z } from "zod";
 
+import { clearOctagonConversationForToolChange } from "../toolSessionState.js";
+
 const TOOL_NAME = "prediction_markets_history";
 const TOOL_DESCRIPTION = `Fetch historical data for a prediction market event by ticker.
 Supports pagination (limit, cursor) and time window (captured_from, captured_to) and optionally include analysis columns.
@@ -9,7 +11,7 @@ Supports pagination (limit, cursor) and time window (captured_from, captured_to)
 Note: For a typical Kalshi Market URL, the event ticker is the final segment in the URL.
 For example, for the URL https://kalshi.com/markets/kxbtcy/btc-price-range-eoy/kxbtcy-27jan0100, the event ticker is kxbtcy-27jan0100.`;
 
-const INPUT_SCHEMA = {
+const predictionMarketsHistoryInputShape = {
   event_ticker: z
     .string()
     .describe(
@@ -37,6 +39,17 @@ const INPUT_SCHEMA = {
     .describe("If true, include heavy analysis columns in the response"),
 };
 
+export const predictionMarketsHistoryInputSchema = z
+  .object(predictionMarketsHistoryInputShape)
+  .strict();
+
+type PredictionMarketsHistoryClient = OpenAI & {
+  get: (
+    path: string,
+    options: { query: Record<string, string | number> },
+  ) => Promise<unknown>;
+};
+
 type Params = {
   event_ticker: string;
   limit: number | undefined;
@@ -46,61 +59,87 @@ type Params = {
   include_analysis: boolean | undefined;
 };
 
+type ToolExtra = {
+  sessionId?: string;
+};
+
+export async function executePredictionMarketsHistoryTool(
+  client: PredictionMarketsHistoryClient,
+  params: Params,
+  extra?: ToolExtra,
+) {
+  try {
+    clearOctagonConversationForToolChange(extra, TOOL_NAME);
+    const eventTicker = encodeURIComponent(params.event_ticker.trim());
+
+    const query: Record<string, string | number> = {};
+    if (params.limit != null) query.limit = params.limit;
+    if (params.cursor != null) query.cursor = params.cursor;
+    if (params.captured_from != null) {
+      query.captured_from = params.captured_from;
+    }
+    if (params.captured_to != null) query.captured_to = params.captured_to;
+    if (params.include_analysis === true) query.include = "analysis";
+
+    const data = await client.get(
+      `/prediction-markets/events/${eventTicker}/history`,
+      { query },
+    );
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: typeof data === "string" ? data : JSON.stringify(data),
+        },
+      ],
+    };
+  } catch (error) {
+    console.error(`Error calling ${TOOL_NAME}:`, error);
+
+    let errorMessage = (error as Error).message ?? String(error);
+    let errorCode = "unknown";
+
+    if (error instanceof APIError) {
+      const err = error.error as { message?: string } | undefined;
+      errorMessage = err?.message ?? errorMessage;
+      errorCode = error.code ?? errorCode;
+    }
+
+    return {
+      isError: true as const,
+      content: [
+        {
+          type: "text" as const,
+          text:
+            errorCode !== "unknown"
+              ? `Error [${errorCode}]: ${errorMessage}`
+              : `Error: Failed to fetch prediction markets history for ${params.event_ticker}.`,
+        },
+      ],
+    };
+  }
+}
+
 export function registerTool(server: McpServer, client: OpenAI): void {
-  (server as any).tool(
+  const toolServer = server as unknown as {
+    tool: (
+      name: string,
+      description: string,
+      inputSchema: Record<string, z.ZodTypeAny>,
+      callback: (args: Params, extra?: ToolExtra) => Promise<unknown>,
+    ) => unknown;
+  };
+
+  toolServer.tool(
     TOOL_NAME,
     TOOL_DESCRIPTION,
-    INPUT_SCHEMA,
-    async (params: Params) => {
-      try {
-        const eventTicker = encodeURIComponent(params.event_ticker.trim());
-
-        const query: Record<string, string | number> = {};
-        if (params.limit != null) query.limit = params.limit;
-        if (params.cursor != null) query.cursor = params.cursor;
-        if (params.captured_from != null)
-          query.captured_from = params.captured_from;
-        if (params.captured_to != null) query.captured_to = params.captured_to;
-        if (params.include_analysis === true) query.include = "analysis";
-
-        const data = await (client as any).get(
-          `/prediction-markets/events/${eventTicker}/history`,
-          { query },
-        );
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: typeof data === "string" ? data : JSON.stringify(data),
-            },
-          ],
-        };
-      } catch (error) {
-        console.error(`Error calling ${TOOL_NAME}:`, error);
-
-        let errorMessage = (error as Error).message ?? String(error);
-        let errorCode = "unknown";
-
-        if (error instanceof APIError) {
-          const err = error.error as { message?: string } | undefined;
-          errorMessage = err?.message ?? errorMessage;
-          errorCode = error.code ?? errorCode;
-        }
-
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text" as const,
-              text:
-                errorCode !== "unknown"
-                  ? `Error [${errorCode}]: ${errorMessage}`
-                  : `Error: Failed to fetch prediction markets history for ${params.event_ticker}.`,
-            },
-          ],
-        };
-      }
-    },
+    predictionMarketsHistoryInputShape,
+    async (params, extra) =>
+      executePredictionMarketsHistoryTool(
+        client as PredictionMarketsHistoryClient,
+        params,
+        extra,
+      ),
   );
 }

--- a/src/tools/predictionMarketsHistory.ts
+++ b/src/tools/predictionMarketsHistory.ts
@@ -2,7 +2,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI, { APIError } from "openai";
 import { z } from "zod";
 
-import { clearOctagonConversationForToolChange } from "../toolSessionState.js";
+import {
+  clearOctagonConversationForToolChange,
+  normalizeToolContext,
+  type SessionExtra,
+} from "../toolSessionState.js";
 
 const TOOL_NAME = "prediction_markets_history";
 const TOOL_DESCRIPTION = `Fetch historical data for a prediction market event by ticker.
@@ -59,17 +63,13 @@ type Params = {
   include_analysis: boolean | undefined;
 };
 
-type ToolExtra = {
-  sessionId?: string;
-};
-
 export async function executePredictionMarketsHistoryTool(
   client: PredictionMarketsHistoryClient,
   params: Params,
-  extra?: ToolExtra,
+  extra?: SessionExtra,
 ) {
   try {
-    clearOctagonConversationForToolChange(extra, TOOL_NAME);
+    clearOctagonConversationForToolChange(normalizeToolContext(extra), TOOL_NAME);
     const eventTicker = encodeURIComponent(params.event_ticker.trim());
 
     const query: Record<string, string | number> = {};
@@ -127,7 +127,7 @@ export function registerTool(server: McpServer, client: OpenAI): void {
       name: string,
       description: string,
       inputSchema: Record<string, z.ZodTypeAny>,
-      callback: (args: Params, extra?: ToolExtra) => Promise<unknown>,
+      callback: (args: Params, extra?: SessionExtra) => Promise<unknown>,
     ) => unknown;
   };
 

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,20 +1,171 @@
 import OpenAI from "openai";
 
+import { debugLog } from "../debug.js";
+
+type ResponseOutputTextLike = {
+  type?: string;
+  text?: string;
+};
+
+type ResponseOutputMessageLike = {
+  type?: string;
+  content?: unknown[];
+};
+
+type OctagonResponseLike = {
+  id?: unknown;
+  conversation?: unknown;
+  output_text?: unknown;
+  output?: unknown[];
+  metadata?: unknown;
+};
+
+export type OctagonFollowUp = {
+  required: boolean;
+  instructions?: string;
+  inputTemplate?: string;
+  exampleRequest?: string;
+  missingIdentifier?: string;
+  reason?: string;
+  source?: string;
+};
+
+export type OctagonAgentResponse = {
+  model: "octagon-agent";
+  text: string;
+  conversation?: string;
+  responseId?: string;
+  followUp?: OctagonFollowUp;
+  rawMetadata?: Record<string, string>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function normalizeMetadata(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const metadata: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === "string") {
+      metadata[key] = entry;
+      continue;
+    }
+
+    if (entry === null) {
+      metadata[key] = "null";
+      continue;
+    }
+
+    if (typeof entry === "boolean") {
+      metadata[key] = entry ? "true" : "false";
+      continue;
+    }
+
+    if (typeof entry === "number") {
+      metadata[key] = String(entry);
+      continue;
+    }
+
+    try {
+      metadata[key] = JSON.stringify(entry);
+    } catch {
+      metadata[key] = String(entry);
+    }
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function extractTextFromOutput(output: unknown): string {
+  if (!Array.isArray(output)) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  for (const item of output) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    if (item.type !== "message") {
+      continue;
+    }
+
+    const message = item as ResponseOutputMessageLike;
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (!isRecord(part)) {
+        continue;
+      }
+
+      const outputText = part as ResponseOutputTextLike;
+      if (outputText.type === "output_text" && typeof outputText.text === "string") {
+        parts.push(outputText.text);
+      }
+    }
+  }
+
+  return parts.join("");
+}
+
+function extractResponseText(response: OctagonResponseLike): string {
+  const outputText = asNonEmptyString(response.output_text);
+  if (outputText) {
+    return outputText;
+  }
+
+  return extractTextFromOutput(response.output);
+}
+
+function extractFollowUp(
+  metadata: Record<string, string> | undefined,
+): OctagonFollowUp | undefined {
+  if (!metadata || metadata.follow_up_required !== "true") {
+    return undefined;
+  }
+
+  return {
+    required: true,
+    instructions: metadata.follow_up_instructions,
+    inputTemplate: metadata.follow_up_input_template,
+    exampleRequest: metadata.follow_up_example_request,
+    missingIdentifier: metadata.follow_up_missing_identifier,
+    reason: metadata.follow_up_reason,
+    source: metadata.follow_up_source,
+  };
+}
+
 export async function processStreamingResponse(
-  stream: AsyncIterable<any>,
+  stream: AsyncIterable<unknown>,
 ): Promise<string> {
   let fullResponse = "";
 
   try {
     for await (const chunk of stream) {
-      if (chunk.type === "response.output_text.delta") {
-        // Responses API streaming text token.
-        if (typeof chunk.delta === "string") {
-          fullResponse += chunk.delta;
-        } else if (typeof chunk.text?.delta === "string") {
-          fullResponse += chunk.text.delta;
-        }
+      if (!isRecord(chunk) || chunk.type !== "response.output_text.delta") {
         continue;
+      }
+
+      if (typeof chunk.delta === "string") {
+        fullResponse += chunk.delta;
+      } else if (
+        isRecord(chunk.text) &&
+        typeof chunk.text.delta === "string"
+      ) {
+        fullResponse += chunk.text.delta;
       }
     }
 
@@ -25,7 +176,7 @@ export async function processStreamingResponse(
   }
 }
 
-export async function createResponse(
+export async function createStreamingTextResponse(
   client: OpenAI,
   model: string,
   prompt: string,
@@ -37,6 +188,50 @@ export async function createResponse(
     metadata: { tool: "mcp" },
   });
 
-  // Process the streaming response and return the full response as a string
   return await processStreamingResponse(response);
+}
+
+export async function createOctagonAgentResponse(
+  client: OpenAI,
+  {
+    prompt,
+    conversation,
+  }: {
+    prompt: string;
+    conversation?: string;
+  },
+): Promise<OctagonAgentResponse> {
+  const response = (await (
+    client.responses.create as unknown as (params: unknown) => Promise<unknown>
+  ).call(client.responses, {
+    model: "octagon-agent",
+    input: prompt,
+    metadata: { tool: "mcp" },
+    ...(conversation ? { conversation } : {}),
+  })) as OctagonResponseLike;
+
+  debugLog("octagon-agent raw Octagon response", response);
+
+  const rawMetadata = normalizeMetadata(response.metadata);
+  const text = extractResponseText(response);
+
+  const parsedResponse: OctagonAgentResponse = {
+    model: "octagon-agent",
+    text,
+    conversation: asNonEmptyString(response.conversation),
+    responseId: asNonEmptyString(response.id),
+    followUp: extractFollowUp(rawMetadata),
+    rawMetadata,
+  };
+
+  debugLog("octagon-agent parsed MCP response payload", parsedResponse);
+
+  return parsedResponse;
+}
+
+export function createTextErrorResult(message: string) {
+  return {
+    isError: true as const,
+    content: [{ type: "text" as const, text: message }],
+  };
 }

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,7 +1,5 @@
 import OpenAI from "openai";
 
-import { debugLog } from "../debug.js";
-
 type ResponseOutputTextLike = {
   type?: string;
   text?: string;
@@ -210,8 +208,6 @@ export async function createOctagonAgentResponse(
     ...(conversation ? { conversation } : {}),
   })) as OctagonResponseLike;
 
-  debugLog("octagon-agent raw Octagon response", response);
-
   const rawMetadata = normalizeMetadata(response.metadata);
   const text = extractResponseText(response);
 
@@ -223,8 +219,6 @@ export async function createOctagonAgentResponse(
     followUp: extractFollowUp(rawMetadata),
     rawMetadata,
   };
-
-  debugLog("octagon-agent parsed MCP response payload", parsedResponse);
 
   return parsedResponse;
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.0.23";
+export const VERSION = "1.1.0";

--- a/tests/octagon-agent-threading.test.js
+++ b/tests/octagon-agent-threading.test.js
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deepResearchInputSchema,
+  executeDeepResearchTool,
+} from "../dist/tools/deepResearchAgent.js";
+import {
+  executeOctagonAgentTool,
+  octagonAgentInputSchema,
+} from "../dist/tools/octagonAgent.js";
+
+test("octagon-agent first turn returns structured conversation metadata", async () => {
+  let capturedRequest;
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequest = request;
+        return {
+          id: "resp_123",
+          conversation: "conv_123",
+          output_text: "Which stock would you like the latest price for?",
+          metadata: {
+            follow_up_required: "true",
+            follow_up_instructions:
+              "Reply with just the missing detail and reuse the conversation value from this response.",
+            follow_up_input_template: "<ticker or company name>",
+            follow_up_example_request:
+              '{"model":"octagon-agent","conversation":"conv_123","input":"<ticker or company name>"}',
+            follow_up_missing_identifier: "company_or_ticker",
+            follow_up_reason: "Missing target company.",
+            follow_up_source: "synthesized",
+          },
+        };
+      },
+    },
+  };
+
+  const result = await executeOctagonAgentTool(
+    client,
+    {
+      prompt: "what is the latest stock price?",
+    },
+    { sessionId: "chat-1" },
+  );
+
+  assert.deepEqual(capturedRequest, {
+    model: "octagon-agent",
+    input: "what is the latest stock price?",
+    metadata: { tool: "mcp" },
+  });
+  assert.deepEqual(result.content, [
+    {
+      type: "text",
+      text: "Which stock would you like the latest price for?",
+    },
+  ]);
+  assert.equal(result.structuredContent?.conversation, "conv_123");
+  assert.equal(result.structuredContent?.responseId, "resp_123");
+  assert.deepEqual(result.structuredContent?.followUp, {
+    required: true,
+    instructions:
+      "Reply with just the missing detail and reuse the conversation value from this response.",
+    inputTemplate: "<ticker or company name>",
+    exampleRequest:
+      '{"model":"octagon-agent","conversation":"conv_123","input":"<ticker or company name>"}',
+    missingIdentifier: "company_or_ticker",
+    reason: "Missing target company.",
+    source: "synthesized",
+  });
+});
+
+test("octagon-agent forwards conversation on later turns", async () => {
+  let capturedRequest;
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequest = request;
+        return {
+          id: "resp_456",
+          conversation: "conv_existing",
+          output_text: "Here is the follow-up answer.",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  const parsed = octagonAgentInputSchema.parse({
+    prompt: "and what about Microsoft?",
+    conversation: "conv_existing",
+  });
+  const result = await executeOctagonAgentTool(client, parsed, {
+    sessionId: "chat-explicit",
+  });
+
+  assert.equal(capturedRequest.conversation, "conv_existing");
+  assert.equal(result.structuredContent?.conversation, "conv_existing");
+  assert.equal(result.content[0].text, "Here is the follow-up answer.");
+});
+
+test("octagon-agent reuses stored conversation in the same session", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_${capturedRequests.length}`,
+          conversation: "conv_session_reused",
+          output_text: "Session-aware answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "first turn" },
+    { sessionId: "chat-reuse" },
+  );
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "second turn without explicit conversation" },
+    { sessionId: "chat-reuse" },
+  );
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, "conv_session_reused");
+});
+
+test("octagon-agent reuses stored conversation with threadKey when sessionId is null", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_thread_${capturedRequests.length}`,
+          conversation: "conv_thread_key",
+          output_text: "Thread-key answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(client, {
+    prompt: "first thread-key turn",
+    threadKey: "visible-chat-1",
+  });
+  await executeOctagonAgentTool(client, {
+    prompt: "follow-up without explicit conversation",
+    threadKey: "visible-chat-1",
+  });
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, "conv_thread_key");
+});
+
+test("octagon-agent does not auto-reuse when sessionId and threadKey are missing", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_no_anchor_${capturedRequests.length}`,
+          conversation: `conv_no_anchor_${capturedRequests.length}`,
+          output_text: "No-anchor answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(client, {
+    prompt: "first turn without safe anchor",
+  });
+  await executeOctagonAgentTool(client, {
+    prompt: "second turn without safe anchor",
+  });
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, undefined);
+});
+
+test("octagon-agent resetConversation drops stored conversation", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_reset_${capturedRequests.length}`,
+          conversation: `conv_reset_${capturedRequests.length}`,
+          output_text: "Reset-aware answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "first turn" },
+    { sessionId: "chat-reset" },
+  );
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "new chat", resetConversation: true },
+    { sessionId: "chat-reset" },
+  );
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, undefined);
+});
+
+test("octagon-agent resetConversation clears the active threadKey anchor", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_thread_reset_${capturedRequests.length}`,
+          conversation: `conv_thread_reset_${capturedRequests.length}`,
+          output_text: "Thread-key reset answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(client, {
+    prompt: "first turn",
+    threadKey: "visible-chat-reset",
+  });
+  await executeOctagonAgentTool(client, {
+    prompt: "reset thread",
+    threadKey: "visible-chat-reset",
+    resetConversation: true,
+  });
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, undefined);
+});
+
+test("non-octagon tools remain non-threaded", async () => {
+  assert.throws(
+    () =>
+      deepResearchInputSchema.parse({
+        prompt: "Research AI infrastructure demand",
+        conversation: "conv_should_fail",
+      }),
+    /Unrecognized key/,
+  );
+
+  const client = {
+    responses: {
+      create: async () => ({
+        [Symbol.asyncIterator]: async function* () {
+          yield {
+            type: "response.output_text.delta",
+            delta: "Deep research answer",
+          };
+        },
+      }),
+    },
+  };
+
+  const result = await executeDeepResearchTool(
+    client,
+    {
+      prompt: "Research AI infrastructure demand",
+    },
+    { sessionId: "chat-non-octagon" },
+  );
+
+  assert.deepEqual(result, {
+    content: [{ type: "text", text: "Deep research answer" }],
+  });
+  assert.ok(!("structuredContent" in result));
+});
+
+test("switching to a non-octagon tool clears stored conversation", async () => {
+  const capturedRequests = [];
+  const octagonClient = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_tool_change_${capturedRequests.length}`,
+          conversation: "conv_tool_change",
+          output_text: "Thread state answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+  const nonOctagonClient = {
+    responses: {
+      create: async () => ({
+        [Symbol.asyncIterator]: async function* () {
+          yield {
+            type: "response.output_text.delta",
+            delta: "Deep research answer",
+          };
+        },
+      }),
+    },
+  };
+
+  await executeOctagonAgentTool(
+    octagonClient,
+    { prompt: "first octagon turn" },
+    { sessionId: "chat-tool-change" },
+  );
+  await executeDeepResearchTool(
+    nonOctagonClient,
+    { prompt: "different tool call" },
+    { sessionId: "chat-tool-change" },
+  );
+  await executeOctagonAgentTool(
+    octagonClient,
+    { prompt: "octagon again" },
+    { sessionId: "chat-tool-change" },
+  );
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, undefined);
+});

--- a/tests/octagon-agent-threading.test.js
+++ b/tests/octagon-agent-threading.test.js
@@ -474,7 +474,7 @@ test("non-octagon tools remain non-threaded", async () => {
   assert.ok(!("structuredContent" in result));
 });
 
-test("switching to a non-octagon tool clears stored conversation", async () => {
+test("non-octagon tools do not modify stored octagon conversation", async () => {
   const capturedRequests = [];
   const octagonClient = {
     responses: {
@@ -519,5 +519,5 @@ test("switching to a non-octagon tool clears stored conversation", async () => {
   );
 
   assert.equal(capturedRequests[0].conversation, undefined);
-  assert.equal(capturedRequests[1].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, "conv_tool_change");
 });

--- a/tests/octagon-agent-threading.test.js
+++ b/tests/octagon-agent-threading.test.js
@@ -9,6 +9,15 @@ import {
   executeOctagonAgentTool,
   octagonAgentInputSchema,
 } from "../dist/tools/octagonAgent.js";
+import {
+  getDefaultStdioSessionIdForTests,
+  resetSessionStateForTests,
+  terminateSession,
+} from "../dist/toolSessionState.js";
+
+test.beforeEach(() => {
+  resetSessionStateForTests();
+});
 
 test("octagon-agent first turn returns structured conversation metadata", async () => {
   let capturedRequest;
@@ -99,7 +108,7 @@ test("octagon-agent forwards conversation on later turns", async () => {
   assert.equal(result.content[0].text, "Here is the follow-up answer.");
 });
 
-test("octagon-agent reuses stored conversation in the same session", async () => {
+test("octagon-agent reuses stored conversation in the same transport session", async () => {
   const capturedRequests = [];
   const client = {
     responses: {
@@ -130,16 +139,50 @@ test("octagon-agent reuses stored conversation in the same session", async () =>
   assert.equal(capturedRequests[1].conversation, "conv_session_reused");
 });
 
-test("octagon-agent reuses stored conversation with threadKey when sessionId is null", async () => {
+test("octagon-agent reuses stored conversation in a transport-backed session", async () => {
   const capturedRequests = [];
   const client = {
     responses: {
       create: async request => {
         capturedRequests.push(request);
         return {
-          id: `resp_thread_${capturedRequests.length}`,
-          conversation: "conv_thread_key",
-          output_text: "Thread-key answer",
+          id: `resp_transport_priority_${capturedRequests.length}`,
+          conversation:
+            capturedRequests.length === 1
+              ? "conv_transport_session"
+              : "conv_transport_followup",
+          output_text: "Transport-priority answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "first turn" },
+    { sessionId: "transport-session-2", transportKind: "streamable_http" },
+  );
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "follow up" },
+    { sessionId: "transport-session-2", transportKind: "streamable_http" },
+  );
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, "conv_transport_session");
+});
+
+test("octagon-agent automatically uses the default stdio session when no anchor is provided", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_stdio_default_${capturedRequests.length}`,
+          conversation: `conv_stdio_default_${capturedRequests.length}`,
+          output_text: "Default stdio answer",
           metadata: { tool: "mcp" },
         };
       },
@@ -147,28 +190,26 @@ test("octagon-agent reuses stored conversation with threadKey when sessionId is 
   };
 
   await executeOctagonAgentTool(client, {
-    prompt: "first thread-key turn",
-    threadKey: "visible-chat-1",
+    prompt: "first turn without explicit anchor",
   });
   await executeOctagonAgentTool(client, {
-    prompt: "follow-up without explicit conversation",
-    threadKey: "visible-chat-1",
+    prompt: "second turn without explicit anchor",
   });
 
   assert.equal(capturedRequests[0].conversation, undefined);
-  assert.equal(capturedRequests[1].conversation, "conv_thread_key");
+  assert.equal(capturedRequests[1].conversation, "conv_stdio_default_1");
 });
 
-test("octagon-agent does not auto-reuse when sessionId and threadKey are missing", async () => {
+test("octagon-agent newConversation forces a fresh thread in the default stdio session", async () => {
   const capturedRequests = [];
   const client = {
     responses: {
       create: async request => {
         capturedRequests.push(request);
         return {
-          id: `resp_no_anchor_${capturedRequests.length}`,
-          conversation: `conv_no_anchor_${capturedRequests.length}`,
-          output_text: "No-anchor answer",
+          id: `resp_new_conversation_${capturedRequests.length}`,
+          conversation: `conv_new_conversation_${capturedRequests.length}`,
+          output_text: "New conversation answer",
           metadata: { tool: "mcp" },
         };
       },
@@ -176,17 +217,52 @@ test("octagon-agent does not auto-reuse when sessionId and threadKey are missing
   };
 
   await executeOctagonAgentTool(client, {
-    prompt: "first turn without safe anchor",
+    prompt: "first chat turn",
   });
   await executeOctagonAgentTool(client, {
-    prompt: "second turn without safe anchor",
+    prompt: "first turn of a new chat",
+    newConversation: true,
+  });
+  await executeOctagonAgentTool(client, {
+    prompt: "follow-up in the new chat",
   });
 
   assert.equal(capturedRequests[0].conversation, undefined);
   assert.equal(capturedRequests[1].conversation, undefined);
+  assert.equal(capturedRequests[2].conversation, "conv_new_conversation_2");
 });
 
-test("octagon-agent resetConversation drops stored conversation", async () => {
+test("octagon-agent rejects conversation with newConversation", async () => {
+  let callCount = 0;
+  const client = {
+    responses: {
+      create: async () => {
+        callCount += 1;
+        return {
+          id: "resp_unexpected_conflict",
+          conversation: "conv_unexpected_conflict",
+          output_text: "Unexpected conflict answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  const result = await executeOctagonAgentTool(client, {
+    prompt: "conflicting request",
+    conversation: "conv_existing",
+    newConversation: true,
+  });
+
+  assert.equal(callCount, 0);
+  assert.equal(result.isError, true);
+  assert.match(
+    result.content[0].text,
+    /cannot include both conversation and newConversation/i,
+  );
+});
+
+test("octagon-agent newConversation drops stored conversation in a transport session", async () => {
   const capturedRequests = [];
   const client = {
     responses: {
@@ -195,7 +271,7 @@ test("octagon-agent resetConversation drops stored conversation", async () => {
         return {
           id: `resp_reset_${capturedRequests.length}`,
           conversation: `conv_reset_${capturedRequests.length}`,
-          output_text: "Reset-aware answer",
+          output_text: "New-conversation-aware answer",
           metadata: { tool: "mcp" },
         };
       },
@@ -209,7 +285,7 @@ test("octagon-agent resetConversation drops stored conversation", async () => {
   );
   await executeOctagonAgentTool(
     client,
-    { prompt: "new chat", resetConversation: true },
+    { prompt: "new chat", newConversation: true },
     { sessionId: "chat-reset" },
   );
 
@@ -217,16 +293,126 @@ test("octagon-agent resetConversation drops stored conversation", async () => {
   assert.equal(capturedRequests[1].conversation, undefined);
 });
 
-test("octagon-agent resetConversation clears the active threadKey anchor", async () => {
+test("octagon-agent explicit conversation overrides the stored session conversation", async () => {
   const capturedRequests = [];
   const client = {
     responses: {
       create: async request => {
         capturedRequests.push(request);
         return {
-          id: `resp_thread_reset_${capturedRequests.length}`,
-          conversation: `conv_thread_reset_${capturedRequests.length}`,
-          output_text: "Thread-key reset answer",
+          id: `resp_override_${capturedRequests.length}`,
+          conversation:
+            capturedRequests.length === 1 ? "conv_session_original" : "conv_branch",
+          output_text: "Override-aware answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "first turn" },
+    { sessionId: "chat-override" },
+  );
+  await executeOctagonAgentTool(
+    client,
+    {
+      prompt: "branch from another thread",
+      conversation: "conv_explicit_branch",
+    },
+    { sessionId: "chat-override" },
+  );
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "continue after override" },
+    { sessionId: "chat-override" },
+  );
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, "conv_explicit_branch");
+  assert.equal(capturedRequests[2].conversation, "conv_branch");
+});
+
+test("octagon-agent isolates conversation state across different sessions", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_isolation_${capturedRequests.length}`,
+          conversation: `conv_isolation_${capturedRequests.length}`,
+          output_text: "Isolation answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "session one first turn" },
+    { sessionId: "chat-isolation-1" },
+  );
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "session two first turn" },
+    { sessionId: "chat-isolation-2" },
+  );
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "session one follow-up" },
+    { sessionId: "chat-isolation-1" },
+  );
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, undefined);
+  assert.equal(capturedRequests[2].conversation, "conv_isolation_1");
+});
+
+test("octagon-agent session termination clears stored session state", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_terminate_${capturedRequests.length}`,
+          conversation: `conv_terminate_${capturedRequests.length}`,
+          output_text: "Terminate-aware answer",
+          metadata: { tool: "mcp" },
+        };
+      },
+    },
+  };
+
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "first turn" },
+    { sessionId: "chat-terminate" },
+  );
+  terminateSession({ sessionId: "chat-terminate" }, "test_cleanup");
+  await executeOctagonAgentTool(
+    client,
+    { prompt: "new session after termination" },
+    { sessionId: "chat-terminate" },
+  );
+
+  assert.equal(capturedRequests[0].conversation, undefined);
+  assert.equal(capturedRequests[1].conversation, undefined);
+});
+
+test("octagon-agent stdio default session can be explicitly terminated", async () => {
+  const capturedRequests = [];
+  const client = {
+    responses: {
+      create: async request => {
+        capturedRequests.push(request);
+        return {
+          id: `resp_stdio_terminate_${capturedRequests.length}`,
+          conversation: `conv_stdio_terminate_${capturedRequests.length}`,
+          output_text: "Terminate stdio answer",
           metadata: { tool: "mcp" },
         };
       },
@@ -235,12 +421,16 @@ test("octagon-agent resetConversation clears the active threadKey anchor", async
 
   await executeOctagonAgentTool(client, {
     prompt: "first turn",
-    threadKey: "visible-chat-reset",
   });
+  terminateSession(
+    {
+      sessionId: getDefaultStdioSessionIdForTests(),
+      transportKind: "stdio",
+    },
+    "test_stdio_cleanup",
+  );
   await executeOctagonAgentTool(client, {
-    prompt: "reset thread",
-    threadKey: "visible-chat-reset",
-    resetConversation: true,
+    prompt: "second turn after termination",
   });
 
   assert.equal(capturedRequests[0].conversation, undefined);


### PR DESCRIPTION
Support explicit conversation IDs plus safe session or thread-key anchored reuse so Octagon threads continue across turns without leaking state across unrelated chats. Add stderr debug logging, focused threading tests, and docs/examples for the updated contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversational threading for octagon-agent with explicit conversation controls and reset option.
  * Improved streaming responses and optional debug logging (toggle via env var).
  * Tool rename: prediction-markets-agent → octagon-prediction-markets-agent.

* **Documentation**
  * README updated with threaded usage guidance and examples.

* **Chores**
  * TypeScript examples updated for multi-turn market intelligence flows.
  * Package version bumped to 1.1.0.

* **Tests**
  * New tests validating octagon-agent threading, propagation, isolation, and tool-switch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->