### PR TITLE
Expose live Octagon docs via MCP.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "octagon-local",
+  "description": "Local marketplace for testing the Octagon Claude Code plugin from the octagon-mcp-server repository.",
+  "owner": {
+    "name": "Octagon AI",
+    "url": "https://github.com/OctagonAI/octagon-mcp-server"
+  },
+  "plugins": [
+    {
+      "name": "octagon-market-intelligence",
+      "description": "Skills-first Claude Code plugin for Octagon market intelligence, prediction market research, and financial analysis workflows.",
+      "source": "./",
+      "version": "1.1.0",
+      "category": "finance",
+      "tags": [
+        "finance",
+        "markets",
+        "octagon",
+        "prediction-markets"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/mcp.json
+++ b/.claude-plugin/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "octagon-mcp": {
+      "command": "node",
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/dist/plugin-runtime.cjs"
+      ],
+      "env": {
+        "OCTAGON_API_KEY": "${user_config.api_key}",
+        "OCTAGON_API_BASE_URL": "${user_config.api_base_url}"
+      }
+    }
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,7 +26,7 @@
       "type": "string",
       "title": "Octagon API key",
       "description": "API key used for Octagon agent and prediction market tool calls.",
-      "sensitive": false,
+      "sensitive": true,
       "required": true
     },
     "api_base_url": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "octagon-market-intelligence",
+  "version": "1.1.0",
+  "description": "Skills-first Claude Code plugin for Octagon market intelligence, prediction market research, and financial analysis workflows.",
+  "author": {
+    "name": "Octagon AI",
+    "url": "https://github.com/OctagonAI/octagon-mcp-server"
+  },
+  "homepage": "https://docs.octagonagents.com",
+  "repository": "https://github.com/OctagonAI/octagon-mcp-server",
+  "license": "MIT",
+  "keywords": [
+    "octagon",
+    "finance",
+    "market-intelligence",
+    "prediction-markets",
+    "claude-code"
+  ],
+  "agents": [
+    "./agents/octagon-research-orchestrator.md"
+  ],
+  "mcpServers": "./.claude-plugin/mcp.json",
+  "userConfig": {
+    "api_key": {
+      "type": "string",
+      "title": "Octagon API key",
+      "description": "API key used for Octagon agent and prediction market tool calls.",
+      "sensitive": false,
+      "required": true
+    },
+    "api_base_url": {
+      "type": "string",
+      "title": "Octagon API base URL",
+      "description": "Optional override for staging, private environments, or self-hosted Octagon API deployments.",
+      "default": "https://api.octagonagents.com/v1"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![smithery badge](https://smithery.ai/badge/@OctagonAI/octagon-mcp-server)](https://smithery.ai/server/@OctagonAI/octagon-mcp-server)
 
-![Favicon](https://docs.octagonagents.com/logo.svg) The Octagon MCP server provides specialized AI-powered financial research and analysis by integrating with the Octagon Market Intelligence API, enabling users to analyze and extract insights from public filings, earnings calls, financial metrics, private market transactions, and prediction market events within Claude Desktop and other popular MCP clients.
+![Favicon](https://octagonai.co/docs/logo.svg) The Octagon MCP server provides specialized AI-powered financial research and analysis by integrating with the Octagon Market Intelligence API, enabling users to analyze and extract insights from public filings, earnings calls, financial metrics, private market transactions, and prediction market events within Claude Desktop and other popular MCP clients.
 
-[![Demo](https://docs.octagonagents.com/financial_model_demo_fast.gif)](https://docs.octagonagents.com/financial_model_demo.mp4)
+[![Demo](https://octagonai.co/docs/financial_model_demo_fast.gif)](https://octagonai.co/docs/financial_model_demo.mp4)
 
 ## Tools
 
@@ -22,6 +22,11 @@
 
 - `octagon-prediction-markets-agent` for Kalshi event research reports
 - `prediction_markets_history` for structured historical market data retrieval
+
+✅ Live Octagon documentation access
+
+- `octagon-docs-search`, `octagon-docs-read`, `octagon-docs-list`, and `octagon-docs-refresh`
+- MCP resources for `octagon-docs://catalog`, `octagon-docs://status`, and `octagon-docs://page/{target}`
 
 ## Get Your Octagon API Key
 
@@ -134,7 +139,7 @@ npm install -g octagon-mcp
 ## Documentation
 
 For comprehensive documentation on using Octagon agents, please visit our official documentation at:
-[https://docs.octagonagents.com](https://docs.octagonagents.com)
+[https://octagonai.co/docs/](https://octagonai.co/docs/)
 
 The documentation includes:
 
@@ -145,11 +150,80 @@ The documentation includes:
 
 For the latest hosted MCP client setup guide, see:
 
-- [Octagon MCP Server Guide](https://docs.octagonagents.com/guide/mcp-server.html)
+- [Octagon MCP Server Guide](https://octagonai.co/docs/guide/mcp-server)
+- [Octagon Claude Plugin Guide](https://octagonai.co/docs/guide/claude-plugin)
+- [Octagon Agents Guide](https://octagonai.co/docs/guide/agents/)
+
+This MCP server also exposes the live docs corpus directly to MCP clients. Documentation access is fetched from the public Octagon docs LLM entry point at `https://octagonai.co/docs/llms.txt`; it does not use or transmit `OCTAGON_API_KEY`.
 
 ## Available Tools
 
 The MCP server currently exposes the following tools:
+
+### Documentation Tools
+
+These tools expose live Octagon docs inside the MCP session. They work even before `OCTAGON_API_KEY` is configured, which makes them useful for setup, troubleshooting, and discovering the right Octagon agent or API workflow.
+
+#### `octagon-docs-list`
+
+Lists live docs sections and pages from the Octagon docs corpus.
+
+**Parameters**
+
+- `section` (string, optional): filter by docs section.
+- `source` (`docs`, `site`, or `all`, optional): defaults to the docs corpus.
+- `limit` (number, optional): maximum entries to return.
+
+#### `octagon-docs-search`
+
+Searches the Octagon API, agent, MCP, and plugin docs with source URLs and optional snippets.
+
+**Parameters**
+
+- `query` (string, required): search query.
+- `section` (string, optional): filter by docs section.
+- `source` (`docs`, `site`, or `all`, optional): defaults to the docs corpus.
+- `limit` (number, optional): maximum results to return.
+- `includeSnippets` (boolean, optional): include matched snippets in results.
+
+Example:
+
+```text
+Search Octagon docs for Claude plugin connector setup.
+```
+
+#### `octagon-docs-read`
+
+Reads one docs page or section as Markdown by title, URL, path, or catalog id.
+
+**Parameters**
+
+- `target` (string, required): docs title, URL, path, or catalog id.
+- `source` (`docs`, `site`, or `all`, optional): defaults to the docs corpus.
+- `maxChars` (number, optional): maximum Markdown characters to return.
+- `preferCachedContent` (boolean, optional): use the indexed docs corpus when available.
+
+Example:
+
+```text
+Read the Octagon MCP server guide.
+```
+
+#### `octagon-docs-refresh`
+
+Refreshes the in-memory docs catalog from the live LLM-friendly docs endpoints.
+
+**Parameters**
+
+- `includeSite` (boolean, optional): also refresh the broader `https://octagonai.co/llms.txt` site index.
+
+### Documentation Resources
+
+Clients that support MCP resources can also browse:
+
+- `octagon-docs://catalog`: normalized live docs catalog.
+- `octagon-docs://status`: cache state, source endpoints, and refresh metadata.
+- `octagon-docs://page/{target}`: one docs page or section as Markdown.
 
 ### `octagon-agent`
 

--- a/agents/octagon-research-orchestrator.md
+++ b/agents/octagon-research-orchestrator.md
@@ -1,0 +1,50 @@
+---
+name: octagon-research-orchestrator
+description: Routes investment research, prediction market, filings, earnings, quote, and analyst-estimate requests to the best Octagon skill or MCP workflow. Use when a request is broad, multi-step, or needs help selecting the right Octagon capability.
+model: sonnet
+effort: medium
+maxTurns: 12
+skills:
+  - octagon-analyst-master
+  - analyst-estimates
+  - prediction-markets-analysis
+  - earnings-call-analysis
+  - sec-10k-analysis
+  - stock-quote
+  - octagon-api-smoke-test
+---
+
+# Octagon Research Orchestrator
+
+You are the routing specialist for the Octagon Claude plugin.
+
+## Primary job
+
+Choose the narrowest useful Octagon workflow first:
+
+1. If the user clearly wants one analyst task, invoke the matching skill.
+2. If the request spans multiple financial workflows, start with `octagon-analyst-master`.
+3. Use direct MCP tools only when no shipped skill cleanly matches the task.
+
+## Routing defaults
+
+- Analyst estimates, consensus, forward expectations: `analyst-estimates`
+- Kalshi event research or prediction market history: `prediction-markets-analysis`
+- Earnings transcript synthesis, guidance, management commentary: `earnings-call-analysis`
+- Annual filing analysis, risks, segments, business model: `sec-10k-analysis`
+- Real-time pricing and market snapshot requests: `stock-quote`
+- Plugin validation, auth checks, tool smoke testing: `octagon-api-smoke-test`
+- Broad company or sector research across several workflows: `octagon-analyst-master`
+
+## Tool selection rules
+
+- Prefer `octagon-agent` for broad market-intelligence questions that need several sources.
+- Prefer `octagon-deep-research-agent` for open-ended multi-source research or thematic investigations.
+- Prefer `octagon-prediction-markets-agent` when a Kalshi URL is present or the user wants a prediction market report.
+- Prefer `prediction_markets_history` for structured event history retrieval.
+
+## Response style
+
+- Keep outputs analyst-oriented and actionable.
+- When the user request is underspecified, ask for the missing ticker, company, period, or Kalshi URL.
+- Preserve Octagon conversation continuity when the tool returns a `conversation` value.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/plugin-session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,12 @@
     "octagon-mcp": "dist/index.js"
   },
   "files": [
-    "dist"
+    ".claude-plugin",
+    "agents",
+    "dist",
+    "hooks",
+    "scripts",
+    "skills"
   ],
   "publishConfig": {
     "access": "public"
@@ -30,7 +35,7 @@
   "scripts": {
     "prebuild": "node scripts/write-version.mjs",
     "build": "tsc && node -e \"require('fs').chmodSync('dist/index.js', '755')\"",
-    "test": "npm run build && node --test tests/octagon-agent-threading.test.js",
+    "test": "npm run build && node --test tests/*.test.js",
     "start": "node dist/index.js",
     "lint": "echo \"No linting configured\"",
     "format": "echo \"No formatting configured\"",

--- a/scripts/plugin-session-start.sh
+++ b/scripts/plugin-session-start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${CLAUDE_PLUGIN_OPTION_api_key:-}" ]; then
+  echo "Octagon plugin is enabled without an API key. Open /plugin to configure api_key before using Octagon tools."
+fi

--- a/skills/analyst-estimates/SKILL.md
+++ b/skills/analyst-estimates/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: analyst-estimates
+description: Retrieve analyst financial estimates including revenue and EPS projections with ranges and coverage. Use when analyzing forward expectations, consensus assumptions, or valuation inputs for a public company.
+---
+
+# Analyst Estimates
+
+Retrieve analyst revenue and EPS expectations for a public company using Octagon MCP.
+
+## Query format
+
+```text
+Retrieve analyst financial estimates for <TICKER> for the annual period, limited to <N> records on page 0.
+```
+
+## MCP call
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "octagon-agent",
+  "arguments": {
+    "prompt": "Retrieve analyst financial estimates for AAPL for the annual period, limited to 10 records on page 0."
+  }
+}
+```
+
+## Output expectations
+
+- Return a table of future periods with revenue and EPS ranges, averages, and analyst coverage
+- After the table, summarize growth trajectory, estimate dispersion, and coverage quality
+
+## Analysis heuristics
+
+- Implied growth: compare future estimates to current actuals
+- Dispersion: wider ranges imply lower conviction
+- Coverage depth: more analysts usually means a stronger consensus
+- Near-term vs long-term: confidence should fall as periods move further out
+
+## Follow-up prompts
+
+- "Compare these estimates to the last three years of actual results."
+- "Calculate the implied forward P/E using the consensus EPS."
+- "What could drive upside or downside versus the consensus?"

--- a/skills/earnings-call-analysis/SKILL.md
+++ b/skills/earnings-call-analysis/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: earnings-call-analysis
+description: Analyze earnings call transcripts for guidance, management commentary, analyst concerns, and strategic signals. Use when the user asks about earnings calls, transcript takeaways, management tone, or future guidance.
+---
+
+# Earnings Call Analysis
+
+Use this skill to extract the most important insights from recent earnings calls.
+
+## Query format
+
+```text
+Analyze the latest earnings call for <COMPANY OR TICKER> and summarize guidance, management commentary, analyst concerns, and strategic takeaways.
+```
+
+## MCP call
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "octagon-agent",
+  "arguments": {
+    "prompt": "Analyze the latest earnings call for AMZN and summarize guidance, management commentary, analyst concerns, and strategic takeaways."
+  }
+}
+```
+
+## Output expectations
+
+- Separate prepared remarks from Q&A when possible
+- Quote or paraphrase management guidance clearly
+- Identify repeat themes, risk signals, and what changed from prior calls
+- End with the top issues to monitor into the next quarter
+
+## Follow-up prompts
+
+- "Focus only on revenue guidance and margin commentary."
+- "What did analysts press management on during Q&A?"
+- "Compare this call to the prior quarter's transcript."

--- a/skills/octagon-analyst-master/SKILL.md
+++ b/skills/octagon-analyst-master/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: octagon-analyst-master
+description: Route broad company, sector, valuation, filings, transcript, and market data questions into the right Octagon workflow. Use when the user wants full-scope investment research or when multiple Octagon skills may be needed.
+---
+
+# Octagon Analyst Master
+
+Use this skill for broad investment research requests that span several analyst workflows.
+
+## When to use
+
+- The user wants a full company brief or investment memo
+- The request mixes filings, estimates, earnings, valuation, and market data
+- It is not obvious which single Octagon skill should be used first
+
+## Routing guide
+
+- Forward estimates and consensus expectations: `analyst-estimates`
+- Kalshi market reports or event history: `prediction-markets-analysis`
+- Earnings transcript and guidance analysis: `earnings-call-analysis`
+- Annual filing and risk review: `sec-10k-analysis`
+- Real-time pricing and market snapshot: `stock-quote`
+
+If the request is still broad after routing, use `octagon-agent`.
+
+## Default query pattern
+
+```text
+Build an investment analyst brief on <COMPANY OR TICKER> covering business quality, latest performance, guidance, valuation context, and key near-term risks.
+```
+
+## MCP call
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "octagon-agent",
+  "arguments": {
+    "prompt": "Build an investment analyst brief on NVDA covering business quality, latest performance, guidance, valuation context, and key near-term risks."
+  }
+}
+```
+
+## Output expectations
+
+- Start with a short investment takeaway
+- Break out the answer by business, financials, expectations, risks, and watch items
+- Call out missing context that would improve the next turn
+
+## Follow-up prompts
+
+- "Compare this company to its two closest public peers."
+- "Now focus only on valuation and forward expectations."
+- "Turn this into a long thesis and a short thesis."

--- a/skills/octagon-analyst-master/SKILL.md
+++ b/skills/octagon-analyst-master/SKILL.md
@@ -23,6 +23,14 @@ Use this skill for broad investment research requests that span several analyst 
 
 If the request is still broad after routing, use `octagon-agent`.
 
+## Docs references
+
+Use the live docs tools when the user asks about setup, available capabilities, or how Octagon works before starting analysis:
+
+- Start with `octagon-docs-search` for discovery: `Claude plugin`, `MCP server`, `available agents`, or `authentication`
+- Use `octagon-docs-read` for canonical context: `Octagon Claude Plugin`, `Octagon MCP Server`, `Octagon Agents Guide`, or `How Octagon API Works`
+- Prefer docs context over memory for installation, connector, authentication, and tool-surface questions
+
 ## Default query pattern
 
 ```text

--- a/skills/octagon-api-smoke-test/SKILL.md
+++ b/skills/octagon-api-smoke-test/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: octagon-api-smoke-test
+description: Validate Octagon plugin configuration and run a lightweight smoke test across the main Octagon MCP workflows. Use when checking whether the plugin is configured correctly, debugging auth, or verifying tool availability.
+---
+
+# Octagon API Smoke Test
+
+Use this skill to confirm that the Claude plugin and Octagon MCP are configured correctly.
+
+## Smoke test sequence
+
+1. Run a simple `octagon-agent` request
+2. Run a simple `octagon-deep-research-agent` request
+3. If a Kalshi URL is available, run `octagon-prediction-markets-agent`
+4. If an event ticker is available, run `prediction_markets_history`
+
+## MCP calls
+
+General agent:
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "octagon-agent",
+  "arguments": {
+    "prompt": "Give me a one-sentence summary of Apple's latest quarter."
+  }
+}
+```
+
+Deep research:
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "octagon-deep-research-agent",
+  "arguments": {
+    "prompt": "Research the current AI infrastructure spending cycle in one short paragraph."
+  }
+}
+```
+
+## Failure triage
+
+- Missing auth or invalid key: check plugin `api_key`
+- Unexpected environment or staging issue: check `api_base_url`
+- Prediction market failures mentioning Kalshi URL: supply a valid Kalshi market URL
+- Credit or entitlement failures: report the exact error and stop
+
+## Success criteria
+
+- At least one Octagon tool returns usable text
+- Tool failures, if any, are classified clearly as config, entitlement, input, or service issues

--- a/skills/prediction-markets-analysis/SKILL.md
+++ b/skills/prediction-markets-analysis/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: prediction-markets-analysis
+description: Generate Kalshi prediction market research reports or fetch structured event history. Use when the user mentions Kalshi, prediction markets, market probability, expected return, or event history.
+---
+
+# Prediction Markets Analysis
+
+Use this skill for Kalshi event research and historical prediction market analysis.
+
+## When to use
+
+- The user shares a Kalshi market URL
+- The user wants a structured report on one prediction market event
+- The user wants event history across snapshots or runs
+
+## Query format
+
+```text
+Generate a report for the Kalshi market <KALSHI_URL>.
+```
+
+For structured history retrieval:
+
+```text
+Fetch historical data for the Kalshi event ticker <EVENT_TICKER>.
+```
+
+## MCP calls
+
+Report generation:
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "octagon-prediction-markets-agent",
+  "arguments": {
+    "prompt": "Generate a report for the Kalshi market https://kalshi.com/markets/kxbtcy/btc-price-range-eoy/kxbtcy-27jan0100"
+  }
+}
+```
+
+Structured history:
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "prediction_markets_history",
+  "arguments": {
+    "event_ticker": "KXBTCY-27JAN0100",
+    "limit": 50,
+    "include_analysis": true
+  }
+}
+```
+
+## Tool selection rules
+
+- Use `octagon-prediction-markets-agent` for analyst-style reports
+- Use `prediction_markets_history` for structured history, pagination, or time filtering
+- If the user wants guaranteed fresh data, set `cache` to `false`
+
+## Output expectations
+
+- Compare model probability to market probability
+- Highlight edge, expected return, and risk factors
+- Surface missing Kalshi URL immediately when absent
+
+## Follow-up prompts
+
+- "Refresh the report instead of using cache."
+- "Show the event history with analysis included."
+- "Summarize the largest drivers of divergence between model and market."

--- a/skills/sec-10k-analysis/SKILL.md
+++ b/skills/sec-10k-analysis/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: sec-10k-analysis
+description: Analyze 10-K annual filings to extract business model, financial priorities, risk factors, segments, and notable changes. Use when the user asks about 10-Ks, annual filings, SEC risk factors, or filing-based due diligence.
+---
+
+# SEC 10-K Analysis
+
+Use this skill for annual filing due diligence and risk review.
+
+## Query format
+
+```text
+Analyze the latest 10-K for <COMPANY OR TICKER> and summarize the business model, key risks, segment performance, and material changes versus the prior year.
+```
+
+## MCP call
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "octagon-agent",
+  "arguments": {
+    "prompt": "Analyze the latest 10-K for MSFT and summarize the business model, key risks, segment performance, and material changes versus the prior year."
+  }
+}
+```
+
+## Output expectations
+
+- Start with a short business overview
+- Pull out the most material risks instead of listing everything
+- Highlight reporting segments, capital allocation, and accounting watch items
+- Compare important changes to the prior annual filing when evidence is available
+
+## Follow-up prompts
+
+- "Expand only the risk factors section."
+- "Compare the current 10-K to last year's filing."
+- "Extract segment performance and margin commentary."

--- a/skills/stock-quote/SKILL.md
+++ b/skills/stock-quote/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: stock-quote
+description: Retrieve a current stock quote and market snapshot with price, range, volume, and moving-average context. Use when the user asks for the latest stock price, quote, intraday range, or a quick market snapshot.
+---
+
+# Stock Quote
+
+Use this skill for quick public-market snapshot requests.
+
+## Query format
+
+```text
+Retrieve the latest stock quote for <TICKER> including current price, volume, day range, 52-week range, and moving-average context.
+```
+
+## MCP call
+
+```json
+{
+  "server": "octagon-mcp",
+  "toolName": "octagon-agent",
+  "arguments": {
+    "prompt": "Retrieve the latest stock quote for NVDA including current price, volume, day range, 52-week range, and moving-average context."
+  }
+}
+```
+
+## Output expectations
+
+- Keep the first answer brief and numeric
+- Call out whether the stock is near the high, low, or midpoint of its recent range
+- Mention unusual volume or trend context if present
+
+## Follow-up prompts
+
+- "Compare that quote to the last month of price action."
+- "Show the same market snapshot for AMD and AVGO."
+- "Now explain what is driving the move."

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,20 +6,16 @@ dotenv.config();
 
 type ClientOptions = Omit<OpenAIClientOptions, "apiKey" | "baseURL">;
 
-// Check for required environment variables
 const OCTAGON_API_KEY = process.env.OCTAGON_API_KEY;
 const OCTAGON_API_BASE_URL =
   process.env.OCTAGON_API_BASE_URL || "https://api.octagonagents.com/v1";
 
-if (!OCTAGON_API_KEY) {
-  console.error(
-    "Error: OCTAGON_API_KEY is not set in the environment variables",
-  );
-  throw new Error("OCTAGON_API_KEY is not set in the environment variables");
-}
-
 // Initialize OpenAI client with Octagon API
 const createClient = (options: ClientOptions) => {
+  if (!OCTAGON_API_KEY) {
+    throw new Error("OCTAGON_API_KEY is not set in the environment variables");
+  }
+
   return new OpenAI({
     apiKey: OCTAGON_API_KEY,
     baseURL: OCTAGON_API_BASE_URL,

--- a/src/docs/catalog.ts
+++ b/src/docs/catalog.ts
@@ -1,0 +1,268 @@
+import {
+  DOCS_DEFAULT_CACHE_TTL_MS,
+  DOCS_PRIMARY_INDEX_URL,
+} from "./config.js";
+import {
+  type DocsCatalog,
+  type DocsCatalogEntry,
+  type DocsSource,
+  type FetchedDocsText,
+} from "./types.js";
+
+type Heading = {
+  level: number;
+  title: string;
+  lineIndex: number;
+};
+
+const PRIMARY_DOCS_ENTRIES = [
+  {
+    title: "Octagon Claude Plugin",
+    url: "https://octagonai.co/docs/guide/claude-plugin",
+    section: "Guides",
+    summary:
+      "Claude plugin setup, connector authentication, hosted Octagon tools, routing, and MCP integration guidance.",
+  },
+  {
+    title: "Octagon Agents Guide",
+    url: "https://octagonai.co/docs/guide/agents/",
+    section: "Guides",
+    summary:
+      "Overview of Octagon public market, private market, deep research, and prediction markets agents.",
+  },
+  {
+    title: "Octagon MCP Server",
+    url: "https://octagonai.co/docs/guide/mcp-server",
+    section: "Guides",
+    summary:
+      "MCP server installation, available tools, Claude Desktop and Cursor setup, and integration behavior.",
+  },
+];
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[`*_~()[\]{}.:,/?#!$&'"|]+/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || "section";
+}
+
+function cleanFetchedMarkdown(markdown: string): string {
+  return markdown
+    .replace(/^Source URL:[^\n]*\nTitle:[^\n]*\n\n/, "")
+    .replace(/\r\n/g, "\n")
+    .trim();
+}
+
+function normalizeDocsUrl(link: string, sourceUrl: string): string {
+  try {
+    return new URL(link, sourceUrl).toString();
+  } catch {
+    return new URL(link, DOCS_PRIMARY_INDEX_URL).toString();
+  }
+}
+
+function pathFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.hash}`;
+  } catch {
+    return url;
+  }
+}
+
+function uniqueId(base: string, seen: Map<string, number>): string {
+  const priorCount = seen.get(base) ?? 0;
+  seen.set(base, priorCount + 1);
+  return priorCount === 0 ? base : `${base}-${priorCount + 1}`;
+}
+
+function extractHeadings(lines: string[]): Heading[] {
+  const headings: Heading[] = [];
+  lines.forEach((line, lineIndex) => {
+    const match = /^(#{1,3})\s+(.+?)\s*$/.exec(line);
+    if (!match) {
+      return;
+    }
+
+    headings.push({
+      level: match[1].length,
+      title: match[2].trim(),
+      lineIndex,
+    });
+  });
+
+  return headings;
+}
+
+function sectionForHeading(headings: Heading[], headingIndex: number): string {
+  const heading = headings[headingIndex];
+  if (heading.level === 1) {
+    return heading.title;
+  }
+
+  for (let i = headingIndex - 1; i >= 0; i -= 1) {
+    if (headings[i].level < heading.level) {
+      return headings[i].title;
+    }
+  }
+
+  return heading.title;
+}
+
+function headingEntries(
+  markdown: string,
+  sourceUrl: string,
+  source: DocsSource,
+  seenIds: Map<string, number>,
+): DocsCatalogEntry[] {
+  const lines = markdown.split("\n");
+  const headings = extractHeadings(lines);
+  const entries: DocsCatalogEntry[] = [];
+
+  headings.forEach((heading, index) => {
+    const nextHeading = headings[index + 1];
+    const endLine = nextHeading?.lineIndex ?? lines.length;
+    const content = lines.slice(heading.lineIndex, endLine).join("\n").trim();
+
+    if (content.length === 0) {
+      return;
+    }
+
+    const slug = slugify(heading.title);
+    const url = `${sourceUrl}#${slug}`;
+    const id = uniqueId(`${source}:${slug}`, seenIds);
+
+    entries.push({
+      id,
+      title: heading.title,
+      url,
+      path: pathFromUrl(url),
+      section: sectionForHeading(headings, index),
+      source,
+      kind: "section",
+      summary: content
+        .split("\n")
+        .slice(1)
+        .find(line => line.trim().length > 0)
+        ?.replace(/^[-*>#\s]+/, "")
+        .slice(0, 280),
+      content,
+    });
+  });
+
+  return entries;
+}
+
+function linkEntries(
+  markdown: string,
+  sourceUrl: string,
+  source: DocsSource,
+  seenIds: Map<string, number>,
+): DocsCatalogEntry[] {
+  const lines = markdown.split("\n");
+  const entries: DocsCatalogEntry[] = [];
+  let currentSection = "Docs";
+
+  for (const line of lines) {
+    const headingMatch = /^(#{1,3})\s+(.+?)\s*$/.exec(line);
+    if (headingMatch) {
+      currentSection = headingMatch[2].trim();
+    }
+
+    const linkPattern = /\[([^\]]+)\]\(([^)]+)\)(?::\s*(.*))?/g;
+    let match: RegExpExecArray | null;
+    while ((match = linkPattern.exec(line)) !== null) {
+      const title = match[1].trim();
+      const url = normalizeDocsUrl(match[2].trim(), sourceUrl);
+      const id = uniqueId(`${source}:${slugify(title)}`, seenIds);
+      const summary = match[3]?.trim();
+
+      entries.push({
+        id,
+        title,
+        url,
+        path: pathFromUrl(url),
+        section: currentSection,
+        source,
+        kind: "link",
+        summary: summary && summary.length > 0 ? summary : undefined,
+      });
+    }
+  }
+
+  return entries;
+}
+
+function dedupeEntries(entries: DocsCatalogEntry[]): DocsCatalogEntry[] {
+  const seen = new Set<string>();
+  const deduped: DocsCatalogEntry[] = [];
+
+  for (const entry of entries) {
+    const key = `${entry.kind}:${entry.url}:${entry.title}`.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(entry);
+  }
+
+  return deduped;
+}
+
+function primaryDocsEntries(
+  source: DocsSource,
+  seenIds: Map<string, number>,
+): DocsCatalogEntry[] {
+  if (source !== "docs") {
+    return [];
+  }
+
+  return PRIMARY_DOCS_ENTRIES.map(entry => ({
+    id: uniqueId(`${source}:${slugify(entry.title)}`, seenIds),
+    title: entry.title,
+    url: entry.url,
+    path: pathFromUrl(entry.url),
+    section: entry.section,
+    source,
+    kind: "link",
+    summary: entry.summary,
+  }));
+}
+
+export function parseDocsCatalog(
+  fetched: FetchedDocsText,
+  {
+    source,
+    cacheTtlMs = DOCS_DEFAULT_CACHE_TTL_MS,
+  }: {
+    source: DocsSource;
+    cacheTtlMs?: number;
+  },
+): DocsCatalog {
+  const rawMarkdown = cleanFetchedMarkdown(fetched.text);
+  const seenIds = new Map<string, number>();
+  const entries = dedupeEntries([
+    ...primaryDocsEntries(source, seenIds),
+    ...headingEntries(rawMarkdown, fetched.finalUrl, source, seenIds),
+    ...linkEntries(rawMarkdown, fetched.finalUrl, source, seenIds),
+  ]);
+  const sections = Array.from(new Set(entries.map(entry => entry.section))).sort(
+    (a, b) => a.localeCompare(b),
+  );
+  const fetchedAtMs = Date.parse(fetched.fetchedAt);
+
+  return {
+    sourceUrl: fetched.finalUrl,
+    source,
+    fetchedAt: fetched.fetchedAt,
+    expiresAt: new Date(fetchedAtMs + cacheTtlMs).toISOString(),
+    entries,
+    sections,
+    rawMarkdown,
+    etag: fetched.etag,
+    lastModified: fetched.lastModified,
+  };
+}

--- a/src/docs/config.ts
+++ b/src/docs/config.ts
@@ -1,0 +1,17 @@
+export const DOCS_PRIMARY_INDEX_URL = "https://octagonai.co/docs/llms.txt";
+export const DOCS_SITE_INDEX_URL = "https://octagonai.co/llms.txt";
+
+export const DOCS_ALLOWED_HOSTS = new Set([
+  "octagonai.co",
+  "www.octagonai.co",
+  "docs.octagonai.co",
+  "docs.octagonagents.com",
+]);
+
+export const DOCS_DEFAULT_TIMEOUT_MS = 10_000;
+export const DOCS_DEFAULT_RETRY_COUNT = 2;
+export const DOCS_DEFAULT_RETRY_DELAY_MS = 250;
+export const DOCS_DEFAULT_CACHE_TTL_MS = 15 * 60 * 1000;
+export const DOCS_DEFAULT_MAX_CHARS = 12_000;
+export const DOCS_MAX_LIMIT = 100;
+export const DOCS_USER_AGENT = "octagon-mcp/docs";

--- a/src/docs/content.ts
+++ b/src/docs/content.ts
@@ -154,6 +154,9 @@ export function contentMatchesTarget(
   const values = [
     entry.id,
     entry.title,
+    `${entry.title} (${entry.section})`,
+    `${entry.title} - ${entry.section}`,
+    `${entry.title} — ${entry.section}`,
     entry.url,
     entry.path,
     entry.path.replace(/^\/docs/, ""),

--- a/src/docs/content.ts
+++ b/src/docs/content.ts
@@ -1,0 +1,238 @@
+import { DOCS_DEFAULT_MAX_CHARS } from "./config.js";
+import { assertAllowedDocsUrl, fetchDocsText } from "./fetcher.js";
+import {
+  type DocsCatalogEntry,
+  type DocsReadResult,
+  type FetchedDocsText,
+} from "./types.js";
+
+function isHtml(contentType: string | undefined, text: string): boolean {
+  return Boolean(
+    contentType?.toLowerCase().includes("text/html") ||
+      /^\s*<!doctype html/i.test(text) ||
+      /^\s*<html[\s>]/i.test(text),
+  );
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function htmlToMarkdown(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, "")
+      .replace(/<style[\s\S]*?<\/style>/gi, "")
+      .replace(/<h1[^>]*>([\s\S]*?)<\/h1>/gi, "\n# $1\n")
+      .replace(/<h2[^>]*>([\s\S]*?)<\/h2>/gi, "\n## $1\n")
+      .replace(/<h3[^>]*>([\s\S]*?)<\/h3>/gi, "\n### $1\n")
+      .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "\n- $1")
+      .replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, "\n$1\n")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<a[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi, "[$2]($1)")
+      .replace(/<[^>]+>/g, "")
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim(),
+  );
+}
+
+function truncateMarkdown(
+  markdown: string,
+  maxChars: number,
+): { markdown: string; truncated: boolean } {
+  if (markdown.length <= maxChars) {
+    return { markdown, truncated: false };
+  }
+
+  return {
+    markdown: `${markdown.slice(0, maxChars).trimEnd()}\n\n[Content truncated. Increase maxChars or read a narrower section to continue.]`,
+    truncated: true,
+  };
+}
+
+function candidateMarkdownUrls(url: string): string[] {
+  const parsed = new URL(url);
+  const withoutHash = new URL(parsed);
+  withoutHash.hash = "";
+  const canonical = withoutHash.toString();
+  const candidates = [canonical];
+  const modernDocsUrl = modernizeDocsUrl(withoutHash);
+
+  if (modernDocsUrl && modernDocsUrl !== canonical) {
+    candidates.unshift(modernDocsUrl);
+  }
+
+  if (
+    canonical.endsWith(".md") ||
+    canonical.endsWith(".txt") ||
+    canonical.endsWith(".html.md")
+  ) {
+    return Array.from(new Set(candidates));
+  }
+
+  if (canonical.endsWith("/")) {
+    candidates.push(`${canonical.slice(0, -1)}.md`);
+    candidates.push(`${canonical}index.md`);
+  } else {
+    candidates.push(`${canonical}.md`);
+    candidates.push(`${canonical}.html.md`);
+  }
+
+  return Array.from(new Set(candidates));
+}
+
+function modernizeDocsUrl(url: URL): string | undefined {
+  let pathname = url.pathname;
+
+  if (url.hostname === "docs.octagonagents.com") {
+    pathname = pathname.replace(/^\/docs/, "");
+  }
+
+  pathname = pathname
+    .replace(/\.html\.md$/, "")
+    .replace(/\.html$/, "")
+    .replace(/\.md$/, "");
+
+  if (!pathname.startsWith("/docs/")) {
+    pathname = `/docs${pathname.startsWith("/") ? "" : "/"}${pathname}`;
+  }
+
+  return `https://octagonai.co${pathname}${url.search}`;
+}
+
+function canonicalTargetValues(value: string): string[] {
+  const normalized = value.trim().toLowerCase();
+  const decoded = decodeURIComponent(normalized);
+  const values = new Set([normalized, decoded]);
+
+  try {
+    const parsed = new URL(decoded);
+    const withoutHash = new URL(parsed);
+    withoutHash.hash = "";
+    const modern = modernizeDocsUrl(withoutHash);
+    const paths = [
+      `${parsed.pathname}${parsed.hash}`,
+      parsed.pathname,
+      parsed.pathname.replace(/^\/docs/, ""),
+      parsed.pathname.replace(/\.html\.md$/, ""),
+      parsed.pathname.replace(/\.html$/, ""),
+      parsed.pathname.replace(/\.md$/, ""),
+    ];
+
+    if (modern) {
+      values.add(modern.toLowerCase());
+      const modernParsed = new URL(modern);
+      paths.push(modernParsed.pathname);
+    }
+
+    for (const path of paths) {
+      values.add(path.toLowerCase());
+    }
+  } catch {
+    // Plain titles and ids are handled by the raw normalized values.
+  }
+
+  return Array.from(values).filter(Boolean);
+}
+
+export function contentMatchesTarget(
+  entry: DocsCatalogEntry,
+  target: string,
+): boolean {
+  const targets = canonicalTargetValues(target);
+  const values = [
+    entry.id,
+    entry.title,
+    entry.url,
+    entry.path,
+    entry.path.replace(/^\/docs/, ""),
+    entry.path.replace(/\.html\.md$/, ""),
+    entry.path.replace(/\.html$/, ""),
+    entry.path.replace(/\.md$/, ""),
+  ].map(value => value.toLowerCase());
+
+  return values.some(value =>
+    targets.some(targetValue => value === targetValue || value.includes(targetValue)),
+  );
+}
+
+export function createDirectUrlEntry(target: string): DocsCatalogEntry | undefined {
+  try {
+    const url = assertAllowedDocsUrl(target).toString();
+    return {
+      id: `direct:${url}`,
+      title: url,
+      url,
+      path: new URL(url).pathname,
+      section: "Direct URL",
+      source: "docs",
+      kind: "link",
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function fetchEntryMarkdown(
+  entry: DocsCatalogEntry,
+): Promise<FetchedDocsText> {
+  let lastError: unknown;
+
+  for (const candidate of candidateMarkdownUrls(entry.url)) {
+    try {
+      return await fetchDocsText(candidate);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Unable to fetch docs page: ${entry.url}`);
+}
+
+export async function readEntry(
+  entry: DocsCatalogEntry,
+  {
+    maxChars = DOCS_DEFAULT_MAX_CHARS,
+    preferCachedContent = true,
+  }: {
+    maxChars?: number;
+    preferCachedContent?: boolean;
+  } = {},
+): Promise<DocsReadResult> {
+  if (preferCachedContent && entry.content) {
+    const truncated = truncateMarkdown(entry.content, maxChars);
+    return {
+      entry,
+      markdown: truncated.markdown,
+      sourceUrl: entry.url,
+      canonicalUrl: entry.url,
+      fetchedAt: new Date().toISOString(),
+      truncated: truncated.truncated,
+    };
+  }
+
+  const fetched = await fetchEntryMarkdown(entry);
+  const markdown = isHtml(fetched.contentType, fetched.text)
+    ? htmlToMarkdown(fetched.text)
+    : fetched.text.trim();
+  const truncated = truncateMarkdown(markdown, maxChars);
+
+  return {
+    entry,
+    markdown: truncated.markdown,
+    sourceUrl: entry.url,
+    canonicalUrl: fetched.finalUrl,
+    fetchedAt: fetched.fetchedAt,
+    truncated: truncated.truncated,
+    etag: fetched.etag,
+    lastModified: fetched.lastModified,
+  };
+}

--- a/src/docs/content.ts
+++ b/src/docs/content.ts
@@ -108,7 +108,12 @@ function modernizeDocsUrl(url: URL): string | undefined {
 
 function canonicalTargetValues(value: string): string[] {
   const normalized = value.trim().toLowerCase();
-  const decoded = decodeURIComponent(normalized);
+  let decoded = normalized;
+  try {
+    decoded = decodeURIComponent(normalized);
+  } catch {
+    // Keep the raw value when the user supplies malformed percent-encoding.
+  }
   const values = new Set([normalized, decoded]);
 
   try {

--- a/src/docs/fetcher.ts
+++ b/src/docs/fetcher.ts
@@ -1,0 +1,145 @@
+import {
+  DOCS_ALLOWED_HOSTS,
+  DOCS_DEFAULT_RETRY_COUNT,
+  DOCS_DEFAULT_RETRY_DELAY_MS,
+  DOCS_DEFAULT_TIMEOUT_MS,
+  DOCS_USER_AGENT,
+} from "./config.js";
+import { type FetchedDocsText } from "./types.js";
+
+type FetchDocsTextOptions = {
+  timeoutMs?: number;
+  retryCount?: number;
+  retryDelayMs?: number;
+  headers?: Record<string, string>;
+};
+
+class DocsHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`Docs fetch failed with HTTP ${status}`);
+    this.status = status;
+  }
+}
+
+export function assertAllowedDocsUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Invalid docs URL: ${value}`);
+  }
+
+  if (!["http:", "https:"].includes(url.protocol)) {
+    throw new Error(`Unsupported docs URL protocol: ${url.protocol}`);
+  }
+
+  if (!DOCS_ALLOWED_HOSTS.has(url.hostname)) {
+    throw new Error(`Unsupported docs URL host: ${url.hostname}`);
+  }
+
+  return url;
+}
+
+function createTimeoutSignal(timeoutMs: number): {
+  signal: AbortSignal;
+  clear: () => void;
+} {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timeout),
+  };
+}
+
+function shouldRetry(error: unknown): boolean {
+  if (error instanceof DocsHttpError) {
+    return error.status === 429 || error.status >= 500;
+  }
+
+  return true;
+}
+
+async function wait(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return;
+  }
+
+  await new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function fetchDocsTextOnce(
+  parsedUrl: URL,
+  timeoutMs: number,
+  headers: Record<string, string> | undefined,
+): Promise<FetchedDocsText> {
+  const timeout = createTimeoutSignal(timeoutMs);
+
+  try {
+    const response = await fetch(parsedUrl, {
+      redirect: "follow",
+      signal: timeout.signal,
+      headers: {
+        "User-Agent": DOCS_USER_AGENT,
+        Accept: "text/markdown,text/plain,text/html;q=0.9,*/*;q=0.1",
+        ...headers,
+      },
+    });
+
+    if (!response.ok) {
+      throw new DocsHttpError(response.status);
+    }
+
+    const contentType = response.headers.get("content-type") ?? undefined;
+    const text = await response.text();
+
+    return {
+      url: parsedUrl.toString(),
+      finalUrl: response.url || parsedUrl.toString(),
+      text,
+      contentType,
+      etag: response.headers.get("etag") ?? undefined,
+      lastModified: response.headers.get("last-modified") ?? undefined,
+      fetchedAt: new Date().toISOString(),
+    };
+  } catch (error) {
+    if (timeout.signal.aborted) {
+      throw new Error(`Docs fetch timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    timeout.clear();
+  }
+}
+
+export async function fetchDocsText(
+  url: string,
+  options: FetchDocsTextOptions = {},
+): Promise<FetchedDocsText> {
+  const parsedUrl = assertAllowedDocsUrl(url);
+  const timeoutMs = options.timeoutMs ?? DOCS_DEFAULT_TIMEOUT_MS;
+  const retryCount = options.retryCount ?? DOCS_DEFAULT_RETRY_COUNT;
+  const retryDelayMs = options.retryDelayMs ?? DOCS_DEFAULT_RETRY_DELAY_MS;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retryCount; attempt += 1) {
+    try {
+      return await fetchDocsTextOnce(parsedUrl, timeoutMs, options.headers);
+    } catch (error) {
+      lastError = error;
+      if (attempt >= retryCount || !shouldRetry(error)) {
+        break;
+      }
+
+      await wait(retryDelayMs * (attempt + 1));
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Failed to fetch ${parsedUrl.toString()}`);
+}

--- a/src/docs/index.ts
+++ b/src/docs/index.ts
@@ -1,0 +1,12 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { registerDocsResources } from "./resources.js";
+import { defaultDocsService } from "./service.js";
+import { registerDocsTools } from "./tools.js";
+
+export function registerDocs(server: McpServer): void {
+  registerDocsResources(server, defaultDocsService);
+  registerDocsTools(server, defaultDocsService);
+}
+
+export { OctagonDocsService, defaultDocsService } from "./service.js";

--- a/src/docs/resources.ts
+++ b/src/docs/resources.ts
@@ -1,0 +1,120 @@
+import {
+  McpServer,
+  ResourceTemplate,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  defaultDocsService,
+  type OctagonDocsService,
+} from "./service.js";
+
+function jsonText(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export function encodeDocsResourceTarget(target: string): string {
+  return encodeURIComponent(target);
+}
+
+export function registerDocsResources(
+  server: McpServer,
+  service: OctagonDocsService = defaultDocsService,
+): void {
+  server.registerResource(
+    "octagon-docs-catalog",
+    "octagon-docs://catalog",
+    {
+      title: "Octagon Docs Catalog",
+      description:
+        "Live catalog of Octagon documentation entries from the docs LLM corpus.",
+      mimeType: "application/json",
+    },
+    async uri => {
+      const catalogs = await service.getCatalog();
+      return {
+        contents: [
+          {
+            uri: uri.toString(),
+            mimeType: "application/json",
+            text: jsonText(catalogs),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerResource(
+    "octagon-docs-status",
+    "octagon-docs://status",
+    {
+      title: "Octagon Docs Status",
+      description:
+        "In-memory Octagon docs cache state, source endpoints, and refresh metadata.",
+      mimeType: "application/json",
+    },
+    uri => ({
+      contents: [
+        {
+          uri: uri.toString(),
+          mimeType: "application/json",
+          text: jsonText(service.status()),
+        },
+      ],
+    }),
+  );
+
+  server.registerResource(
+    "octagon-docs-page",
+    new ResourceTemplate("octagon-docs://page/{target}", {
+      list: async () => {
+        const entries = await service.list({ limit: 100 });
+        return {
+          resources: entries.map(entry => ({
+            uri: `octagon-docs://page/${encodeDocsResourceTarget(entry.id)}`,
+            name: entry.id,
+            title: entry.title,
+            description: entry.summary,
+            mimeType: "text/markdown",
+          })),
+        };
+      },
+      complete: {
+        target: async value => {
+          const entries = await service.list({ limit: 100 });
+          const normalized = value.toLowerCase();
+          return entries
+            .filter(
+              entry =>
+                entry.id.toLowerCase().includes(normalized) ||
+                entry.title.toLowerCase().includes(normalized),
+            )
+            .slice(0, 20)
+            .map(entry => entry.id);
+        },
+      },
+    }),
+    {
+      title: "Octagon Docs Page",
+      description:
+        "A single Octagon documentation page or section as Markdown.",
+      mimeType: "text/markdown",
+    },
+    async (uri, variables) => {
+      const targetValue = Array.isArray(variables.target)
+        ? variables.target[0]
+        : variables.target;
+      const target = decodeURIComponent(String(targetValue ?? ""));
+      const result = await service.read({ target });
+
+      return {
+        contents: [
+          {
+            uri: uri.toString(),
+            mimeType: "text/markdown",
+            text: result.markdown,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/docs/search.ts
+++ b/src/docs/search.ts
@@ -1,0 +1,138 @@
+import { type DocsCatalogEntry, type DocsSearchResult } from "./types.js";
+
+const STOP_WORDS = new Set([
+  "and",
+  "api",
+  "can",
+  "complete",
+  "docs",
+  "example",
+  "examples",
+  "for",
+  "from",
+  "guide",
+  "how",
+  "integration",
+  "the",
+  "this",
+  "use",
+  "using",
+  "with",
+]);
+
+function tokenize(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(token => token.length >= 2),
+    ),
+  );
+}
+
+function distinctiveTokens(tokens: string[]): string[] {
+  const distinctive = tokens.filter(
+    token => token.length >= 3 && !STOP_WORDS.has(token),
+  );
+
+  return distinctive.length > 0 ? distinctive : tokens;
+}
+
+function countMatches(value: string, tokens: string[]): number {
+  const lower = value.toLowerCase();
+  return tokens.reduce(
+    (count, token) => count + (lower.includes(token) ? 1 : 0),
+    0,
+  );
+}
+
+function createSnippet(entry: DocsCatalogEntry, tokens: string[]): string | undefined {
+  const haystack = entry.content ?? entry.summary;
+  if (!haystack) {
+    return undefined;
+  }
+
+  const lower = haystack.toLowerCase();
+  const index = tokens
+    .map(token => lower.indexOf(token))
+    .filter(position => position >= 0)
+    .sort((a, b) => a - b)[0];
+
+  if (index === undefined) {
+    return haystack.slice(0, 240).trim();
+  }
+
+  const start = Math.max(0, index - 100);
+  const end = Math.min(haystack.length, index + 180);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < haystack.length ? "..." : "";
+
+  return `${prefix}${haystack.slice(start, end).trim()}${suffix}`;
+}
+
+export function searchDocsEntries(
+  entries: DocsCatalogEntry[],
+  {
+    query,
+    section,
+    limit,
+    includeSnippets,
+  }: {
+    query: string;
+    section?: string;
+    limit: number;
+    includeSnippets: boolean;
+  },
+): DocsSearchResult[] {
+  const tokens = tokenize(query);
+  const normalizedSection = section?.trim().toLowerCase();
+
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  const requiredTokens = distinctiveTokens(tokens);
+
+  return entries
+    .filter(entry =>
+      normalizedSection
+        ? entry.section.toLowerCase().includes(normalizedSection)
+        : true,
+    )
+    .map(entry => {
+      const titleScore = countMatches(entry.title, tokens) * 8;
+      const sectionScore = countMatches(entry.section, tokens) * 4;
+      const summaryScore = countMatches(entry.summary ?? "", tokens) * 3;
+      const contentScore = countMatches(entry.content ?? "", tokens);
+      const distinctiveScore =
+        countMatches(entry.title, requiredTokens) * 10 +
+        countMatches(entry.section, requiredTokens) * 4 +
+        countMatches(entry.summary ?? "", requiredTokens) * 3 +
+        countMatches(entry.content ?? "", requiredTokens);
+      const exactTitleBonus = entry.title
+        .toLowerCase()
+        .includes(query.toLowerCase())
+        ? 12
+        : 0;
+      const hasDistinctiveMatch = distinctiveScore > 0;
+      const score =
+        hasDistinctiveMatch
+          ? titleScore +
+            sectionScore +
+            summaryScore +
+            contentScore +
+            distinctiveScore +
+            exactTitleBonus
+          : 0;
+
+      return {
+        entry,
+        score,
+        snippet: includeSnippets ? createSnippet(entry, tokens) : undefined,
+      };
+    })
+    .filter(result => result.score > 0)
+    .sort((a, b) => b.score - a.score || a.entry.title.localeCompare(b.entry.title))
+    .slice(0, limit);
+}

--- a/src/docs/service.ts
+++ b/src/docs/service.ts
@@ -147,6 +147,8 @@ export class OctagonDocsService {
     source?: DocsSource | "all";
     preferCachedContent?: boolean;
   }): Promise<DocsReadResult> {
+    const catalogs = await this.getCatalog({ includeSite: source === "all" });
+
     const normalizedMaxChars = Math.max(
       1_000,
       Math.min(50_000, Math.floor(maxChars ?? DOCS_DEFAULT_MAX_CHARS)),
@@ -157,7 +159,7 @@ export class OctagonDocsService {
       return cached;
     }
 
-    const entries = (await this.getEntries(source === "all")).filter(entry =>
+    const entries = catalogs.flatMap(catalog => catalog.entries).filter(entry =>
       source === "all" ? true : entry.source === source,
     );
     const matchingEntries = entries.filter(candidate =>
@@ -242,6 +244,7 @@ export class OctagonDocsService {
       catalog,
       expiresAtMs: Date.now() + this.options.cacheTtlMs,
     });
+    this.readCache.clear();
 
     return catalog;
   }

--- a/src/docs/service.ts
+++ b/src/docs/service.ts
@@ -1,0 +1,250 @@
+import {
+  DOCS_DEFAULT_CACHE_TTL_MS,
+  DOCS_DEFAULT_MAX_CHARS,
+  DOCS_MAX_LIMIT,
+  DOCS_PRIMARY_INDEX_URL,
+  DOCS_SITE_INDEX_URL,
+} from "./config.js";
+import { parseDocsCatalog } from "./catalog.js";
+import {
+  contentMatchesTarget,
+  createDirectUrlEntry,
+  readEntry,
+} from "./content.js";
+import { fetchDocsText } from "./fetcher.js";
+import { searchDocsEntries } from "./search.js";
+import {
+  type DocsCatalog,
+  type DocsCatalogEntry,
+  type DocsReadResult,
+  type DocsSearchResult,
+  type DocsSource,
+  type DocsStatus,
+} from "./types.js";
+
+type DocsServiceOptions = {
+  cacheTtlMs?: number;
+  primaryIndexUrl?: string;
+  siteIndexUrl?: string;
+};
+
+type CatalogCacheEntry = {
+  catalog: DocsCatalog;
+  expiresAtMs: number;
+};
+
+function clampLimit(value: number | undefined, defaultValue: number): number {
+  const requested = value ?? defaultValue;
+  if (!Number.isFinite(requested)) {
+    return defaultValue;
+  }
+
+  return Math.max(1, Math.min(DOCS_MAX_LIMIT, Math.floor(requested)));
+}
+
+function sourceUrlFor(source: DocsSource, options: Required<DocsServiceOptions>) {
+  return source === "docs" ? options.primaryIndexUrl : options.siteIndexUrl;
+}
+
+export class OctagonDocsService {
+  private readonly options: Required<DocsServiceOptions>;
+  private readonly catalogs = new Map<DocsSource, CatalogCacheEntry>();
+  private readonly readCache = new Map<string, DocsReadResult>();
+
+  constructor(options: DocsServiceOptions = {}) {
+    this.options = {
+      cacheTtlMs: options.cacheTtlMs ?? DOCS_DEFAULT_CACHE_TTL_MS,
+      primaryIndexUrl: options.primaryIndexUrl ?? DOCS_PRIMARY_INDEX_URL,
+      siteIndexUrl: options.siteIndexUrl ?? DOCS_SITE_INDEX_URL,
+    };
+  }
+
+  async refresh({
+    includeSite = false,
+  }: { includeSite?: boolean } = {}): Promise<DocsCatalog[]> {
+    this.readCache.clear();
+    const sources: DocsSource[] = includeSite ? ["docs", "site"] : ["docs"];
+    const catalogs: DocsCatalog[] = [];
+
+    for (const source of sources) {
+      const catalog = await this.fetchCatalog(source);
+      catalogs.push(catalog);
+    }
+
+    return catalogs;
+  }
+
+  async getCatalog({
+    includeSite = false,
+  }: { includeSite?: boolean } = {}): Promise<DocsCatalog[]> {
+    const sources: DocsSource[] = includeSite ? ["docs", "site"] : ["docs"];
+    const catalogs: DocsCatalog[] = [];
+
+    for (const source of sources) {
+      catalogs.push(await this.getCatalogForSource(source));
+    }
+
+    return catalogs;
+  }
+
+  async list({
+    section,
+    source = "docs",
+    limit,
+  }: {
+    section?: string;
+    source?: DocsSource | "all";
+    limit?: number;
+  } = {}): Promise<DocsCatalogEntry[]> {
+    const entries = await this.getEntries(source === "all");
+    const normalizedSection = section?.trim().toLowerCase();
+
+    return entries
+      .filter(entry =>
+        source === "all" ? true : entry.source === source,
+      )
+      .filter(entry =>
+        normalizedSection
+          ? entry.section.toLowerCase().includes(normalizedSection)
+          : true,
+      )
+      .slice(0, clampLimit(limit, 25));
+  }
+
+  async search({
+    query,
+    section,
+    source = "docs",
+    limit,
+    includeSnippets = true,
+  }: {
+    query: string;
+    section?: string;
+    source?: DocsSource | "all";
+    limit?: number;
+    includeSnippets?: boolean;
+  }): Promise<DocsSearchResult[]> {
+    const entries = (await this.getEntries(source === "all")).filter(entry =>
+      source === "all" ? true : entry.source === source,
+    );
+
+    return searchDocsEntries(entries, {
+      query,
+      section,
+      limit: clampLimit(limit, 10),
+      includeSnippets,
+    });
+  }
+
+  async read({
+    target,
+    maxChars,
+    source = "docs",
+    preferCachedContent = true,
+  }: {
+    target: string;
+    maxChars?: number;
+    source?: DocsSource | "all";
+    preferCachedContent?: boolean;
+  }): Promise<DocsReadResult> {
+    const normalizedMaxChars = Math.max(
+      1_000,
+      Math.min(50_000, Math.floor(maxChars ?? DOCS_DEFAULT_MAX_CHARS)),
+    );
+    const cacheKey = `${source}:${target}:${normalizedMaxChars}:${preferCachedContent}`;
+    const cached = this.readCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const entries = (await this.getEntries(source === "all")).filter(entry =>
+      source === "all" ? true : entry.source === source,
+    );
+    const matchingEntries = entries.filter(candidate =>
+      contentMatchesTarget(candidate, target),
+    );
+    const titleMatch = entries.find(candidate =>
+      candidate.title.toLowerCase().includes(target.trim().toLowerCase()),
+    );
+    const directUrlEntry = createDirectUrlEntry(target);
+    const entry =
+      matchingEntries.sort((a, b) => {
+        const contentScore = Number(Boolean(b.content)) - Number(Boolean(a.content));
+        if (contentScore !== 0) {
+          return contentScore;
+        }
+
+        const titleScore =
+          Number(b.title.toLowerCase() === target.trim().toLowerCase()) -
+          Number(a.title.toLowerCase() === target.trim().toLowerCase());
+        if (titleScore !== 0) {
+          return titleScore;
+        }
+
+        return a.title.localeCompare(b.title);
+      })[0] ??
+      titleMatch ??
+      directUrlEntry;
+
+    if (!entry) {
+      throw new Error(`No Octagon docs page matched "${target}".`);
+    }
+
+    const result = await readEntry(entry, {
+      maxChars: normalizedMaxChars,
+      preferCachedContent,
+    });
+    this.readCache.set(cacheKey, result);
+    return result;
+  }
+
+  status(): DocsStatus {
+    return {
+      primaryIndexUrl: this.options.primaryIndexUrl,
+      siteIndexUrl: this.options.siteIndexUrl,
+      cacheTtlMs: this.options.cacheTtlMs,
+      catalogs: Array.from(this.catalogs.values()).map(({ catalog }) => ({
+        source: catalog.source,
+        sourceUrl: catalog.sourceUrl,
+        fetchedAt: catalog.fetchedAt,
+        expiresAt: catalog.expiresAt,
+        entries: catalog.entries.length,
+        sections: catalog.sections,
+        etag: catalog.etag,
+        lastModified: catalog.lastModified,
+      })),
+      cachedPages: this.readCache.size,
+    };
+  }
+
+  private async getEntries(includeSite: boolean): Promise<DocsCatalogEntry[]> {
+    const catalogs = await this.getCatalog({ includeSite });
+    return catalogs.flatMap(catalog => catalog.entries);
+  }
+
+  private async getCatalogForSource(source: DocsSource): Promise<DocsCatalog> {
+    const cached = this.catalogs.get(source);
+    if (cached && cached.expiresAtMs > Date.now()) {
+      return cached.catalog;
+    }
+
+    return this.fetchCatalog(source);
+  }
+
+  private async fetchCatalog(source: DocsSource): Promise<DocsCatalog> {
+    const fetched = await fetchDocsText(sourceUrlFor(source, this.options));
+    const catalog = parseDocsCatalog(fetched, {
+      source,
+      cacheTtlMs: this.options.cacheTtlMs,
+    });
+
+    this.catalogs.set(source, {
+      catalog,
+      expiresAtMs: Date.now() + this.options.cacheTtlMs,
+    });
+
+    return catalog;
+  }
+}
+
+export const defaultDocsService = new OctagonDocsService();

--- a/src/docs/tools.ts
+++ b/src/docs/tools.ts
@@ -1,0 +1,217 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { createTextErrorResult } from "#tools/shared";
+import { DOCS_DEFAULT_MAX_CHARS } from "./config.js";
+import {
+  defaultDocsService,
+  type OctagonDocsService,
+} from "./service.js";
+
+const sourceSchema = z.enum(["docs", "site", "all"]).optional();
+
+export const docsListInputShape = {
+  section: z.string().trim().min(1).optional(),
+  source: sourceSchema.describe(
+    "Docs source to list. Use docs for API/docs corpus, site for broader site index, or all.",
+  ),
+  limit: z.number().int().min(1).max(100).optional(),
+};
+
+export const docsSearchInputShape = {
+  query: z.string().trim().min(1).describe("Search query for Octagon docs"),
+  section: z.string().trim().min(1).optional(),
+  source: sourceSchema,
+  limit: z.number().int().min(1).max(100).optional(),
+  includeSnippets: z.boolean().optional(),
+};
+
+export const docsReadInputShape = {
+  target: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Docs title, URL, path, or catalog id to read"),
+  source: sourceSchema,
+  maxChars: z.number().int().min(1000).max(50000).optional(),
+  preferCachedContent: z.boolean().optional(),
+};
+
+export const docsRefreshInputShape = {
+  includeSite: z
+    .boolean()
+    .optional()
+    .describe("Also refresh the broader octagonai.co site index"),
+};
+
+type DocsListParams = z.infer<z.ZodObject<typeof docsListInputShape>>;
+type DocsSearchParams = z.infer<z.ZodObject<typeof docsSearchInputShape>>;
+type DocsReadParams = z.infer<z.ZodObject<typeof docsReadInputShape>>;
+type DocsRefreshParams = z.infer<z.ZodObject<typeof docsRefreshInputShape>>;
+
+function summarizeEntries(
+  entries: Array<{ title: string; section: string; url: string; summary?: string }>,
+): string {
+  if (entries.length === 0) {
+    return "No Octagon docs entries matched.";
+  }
+
+  return entries
+    .map(
+      (entry, index) =>
+        `${index + 1}. ${entry.title} (${entry.section})\n${entry.url}${
+          entry.summary ? `\n${entry.summary}` : ""
+        }`,
+    )
+    .join("\n\n");
+}
+
+export async function executeDocsListTool(
+  service: OctagonDocsService,
+  params: DocsListParams,
+) {
+  try {
+    const entries = await service.list(params);
+    return {
+      content: [{ type: "text" as const, text: summarizeEntries(entries) }],
+      structuredContent: {
+        entries,
+        count: entries.length,
+      },
+    };
+  } catch (error) {
+    console.error("Error listing Octagon docs:", error);
+    return createTextErrorResult("Error: Failed to list Octagon docs.");
+  }
+}
+
+export async function executeDocsSearchTool(
+  service: OctagonDocsService,
+  params: DocsSearchParams,
+) {
+  try {
+    const results = await service.search({
+      ...params,
+      includeSnippets: params.includeSnippets ?? true,
+    });
+    const entries = results.map(result => ({
+      ...result.entry,
+      score: result.score,
+      snippet: result.snippet,
+    }));
+
+    return {
+      content: [{ type: "text" as const, text: summarizeEntries(entries) }],
+      structuredContent: {
+        query: params.query,
+        results: entries,
+        count: entries.length,
+      },
+    };
+  } catch (error) {
+    console.error("Error searching Octagon docs:", error);
+    return createTextErrorResult("Error: Failed to search Octagon docs.");
+  }
+}
+
+export async function executeDocsReadTool(
+  service: OctagonDocsService,
+  params: DocsReadParams,
+) {
+  try {
+    const result = await service.read({
+      target: params.target,
+      source: params.source,
+      maxChars: params.maxChars ?? DOCS_DEFAULT_MAX_CHARS,
+      preferCachedContent: params.preferCachedContent ?? true,
+    });
+
+    return {
+      content: [{ type: "text" as const, text: result.markdown }],
+      structuredContent: result,
+    };
+  } catch (error) {
+    console.error("Error reading Octagon docs:", error);
+    return createTextErrorResult(
+      error instanceof Error
+        ? `Error: ${error.message}`
+        : "Error: Failed to read Octagon docs.",
+    );
+  }
+}
+
+export async function executeDocsRefreshTool(
+  service: OctagonDocsService,
+  params: DocsRefreshParams,
+) {
+  try {
+    const catalogs = await service.refresh({
+      includeSite: params.includeSite ?? false,
+    });
+    const text = catalogs
+      .map(
+        catalog =>
+          `${catalog.source}: ${catalog.entries.length} entries from ${catalog.sourceUrl}`,
+      )
+      .join("\n");
+
+    return {
+      content: [{ type: "text" as const, text }],
+      structuredContent: {
+        catalogs: catalogs.map(catalog => ({
+          source: catalog.source,
+          sourceUrl: catalog.sourceUrl,
+          fetchedAt: catalog.fetchedAt,
+          expiresAt: catalog.expiresAt,
+          entries: catalog.entries.length,
+          sections: catalog.sections,
+        })),
+      },
+    };
+  } catch (error) {
+    console.error("Error refreshing Octagon docs:", error);
+    return createTextErrorResult("Error: Failed to refresh Octagon docs.");
+  }
+}
+
+export function registerDocsTools(
+  server: McpServer,
+  service: OctagonDocsService = defaultDocsService,
+): void {
+  const toolServer = server as unknown as {
+    tool: (
+      name: string,
+      description: string,
+      inputSchema: Record<string, z.ZodTypeAny>,
+      callback: (args: Record<string, unknown>) => Promise<unknown>,
+    ) => unknown;
+  };
+
+  toolServer.tool(
+    "octagon-docs-list",
+    "List live Octagon documentation sections and pages from the docs LLM corpus.",
+    docsListInputShape,
+    async params => executeDocsListTool(service, params as DocsListParams),
+  );
+
+  toolServer.tool(
+    "octagon-docs-search",
+    "Search live Octagon API, agent, MCP, and plugin documentation with source URLs.",
+    docsSearchInputShape,
+    async params => executeDocsSearchTool(service, params as DocsSearchParams),
+  );
+
+  toolServer.tool(
+    "octagon-docs-read",
+    "Read a live Octagon docs page or section by title, path, URL, or catalog id.",
+    docsReadInputShape,
+    async params => executeDocsReadTool(service, params as DocsReadParams),
+  );
+
+  toolServer.tool(
+    "octagon-docs-refresh",
+    "Refresh the in-memory Octagon docs catalog from live LLM-friendly docs endpoints.",
+    docsRefreshInputShape,
+    async params => executeDocsRefreshTool(service, params as DocsRefreshParams),
+  );
+}

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -1,0 +1,71 @@
+export type DocsSource = "docs" | "site";
+
+export type DocsCatalogEntryKind = "section" | "link";
+
+export type DocsCatalogEntry = {
+  id: string;
+  title: string;
+  url: string;
+  path: string;
+  section: string;
+  source: DocsSource;
+  kind: DocsCatalogEntryKind;
+  summary?: string;
+  content?: string;
+};
+
+export type DocsCatalog = {
+  sourceUrl: string;
+  source: DocsSource;
+  fetchedAt: string;
+  expiresAt: string;
+  entries: DocsCatalogEntry[];
+  sections: string[];
+  rawMarkdown: string;
+  etag?: string;
+  lastModified?: string;
+};
+
+export type FetchedDocsText = {
+  url: string;
+  finalUrl: string;
+  text: string;
+  contentType?: string;
+  etag?: string;
+  lastModified?: string;
+  fetchedAt: string;
+};
+
+export type DocsReadResult = {
+  entry: DocsCatalogEntry;
+  markdown: string;
+  sourceUrl: string;
+  canonicalUrl: string;
+  fetchedAt: string;
+  truncated: boolean;
+  etag?: string;
+  lastModified?: string;
+};
+
+export type DocsSearchResult = {
+  entry: DocsCatalogEntry;
+  score: number;
+  snippet?: string;
+};
+
+export type DocsStatus = {
+  primaryIndexUrl: string;
+  siteIndexUrl: string;
+  cacheTtlMs: number;
+  catalogs: Array<{
+    source: DocsSource;
+    sourceUrl: string;
+    fetchedAt: string;
+    expiresAt: string;
+    entries: number;
+    sections: string[];
+    etag?: string;
+    lastModified?: string;
+  }>;
+  cachedPages: number;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,9 @@ import createClient from "#client";
 import { registerMcpTools } from "#tools";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import OpenAI from "openai";
 import { OCTAGON_MCP_DEBUG, debugLog } from "./debug.js";
+import { registerDocs } from "./docs/index.js";
 import { VERSION } from "./version.js";
 
 const PACKAGE_NAME = "octagon-mcp";
@@ -20,11 +22,21 @@ async function main() {
       version: VERSION,
     });
 
-    const octagonClient = createClient({
-      defaultHeaders: {
-        "User-Agent": `${PACKAGE_NAME}/${VERSION} (Node.js/${process.versions.node})`,
-      },
-    });
+    let octagonClient: OpenAI | null = null;
+    try {
+      octagonClient = createClient({
+        defaultHeaders: {
+          "User-Agent": `${PACKAGE_NAME}/${VERSION} (Node.js/${process.versions.node})`,
+        },
+      });
+    } catch (error) {
+      console.error(
+        "Warning: OCTAGON_API_KEY is not set. Octagon API-backed tools will return a configuration error, but documentation tools remain available.",
+      );
+      debugLog("Octagon API client unavailable", {
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     debugLog("MCP server starting", {
       packageName: PACKAGE_NAME,
@@ -33,6 +45,7 @@ async function main() {
       transportKind: "stdio",
     });
 
+    registerDocs(server);
     registerMcpTools(server, octagonClient);
 
     transport = new StdioServerTransport();

--- a/src/tools/deepResearchAgent.ts
+++ b/src/tools/deepResearchAgent.ts
@@ -3,7 +3,11 @@ import OpenAI from "openai";
 import { z } from "zod";
 
 import { type SessionExtra } from "../toolSessionState.js";
-import { createStreamingTextResponse, createTextErrorResult } from "#tools/shared";
+import {
+  createMissingApiKeyResult,
+  createStreamingTextResponse,
+  createTextErrorResult,
+} from "#tools/shared";
 
 const AGENT_NAME = "octagon-deep-research-agent";
 const AGENT_DESCRIPTION =
@@ -39,7 +43,7 @@ export async function executeDeepResearchTool(
   }
 }
 
-export function registerTool(server: McpServer, client: OpenAI): void {
+export function registerTool(server: McpServer, client: OpenAI | null): void {
   const toolServer = server as unknown as {
     tool: (
       name: string,
@@ -53,6 +57,9 @@ export function registerTool(server: McpServer, client: OpenAI): void {
     AGENT_NAME,
     AGENT_DESCRIPTION,
     deepResearchInputShape,
-    async (args, extra) => executeDeepResearchTool(client, args, extra),
+    async (args, extra) =>
+      client
+        ? executeDeepResearchTool(client, args, extra)
+        : Promise.resolve(createMissingApiKeyResult()),
   );
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,7 +6,7 @@ import { registerTool as registerOctagonAgentTool } from "#tools/octagonAgent";
 import { registerTool as registerPredictionMarketsTool } from "#tools/predictionMarketsAgent";
 import { registerTool as registerPredictionMarketsHistoryTool } from "#tools/predictionMarketsHistory";
 
-export function registerMcpTools(server: McpServer, client: OpenAI): void {
+export function registerMcpTools(server: McpServer, client: OpenAI | null): void {
   registerDeepResearchTool(server, client);
   registerOctagonAgentTool(server, client);
   registerPredictionMarketsTool(server, client);

--- a/src/tools/octagonAgent.ts
+++ b/src/tools/octagonAgent.ts
@@ -15,7 +15,11 @@ import {
   storeOctagonConversation,
   type SessionExtra,
 } from "../toolSessionState.js";
-import { createOctagonAgentResponse, createTextErrorResult } from "#tools/shared";
+import {
+  createMissingApiKeyResult,
+  createOctagonAgentResponse,
+  createTextErrorResult,
+} from "#tools/shared";
 
 const AGENT_NAME = "octagon-agent";
 const AGENT_DESCRIPTION =
@@ -204,7 +208,7 @@ export async function executeOctagonAgentTool(
   }
 }
 
-export function registerTool(server: McpServer, client: OpenAI): void {
+export function registerTool(server: McpServer, client: OpenAI | null): void {
   const toolServer = server as unknown as {
     tool: (
       name: string,
@@ -222,10 +226,12 @@ export function registerTool(server: McpServer, client: OpenAI): void {
       { prompt, conversation, newConversation }: Params,
       extra?: SessionExtra,
     ) =>
-      executeOctagonAgentTool(
-        client,
-        { prompt, conversation, newConversation },
-        extra,
-      ),
+      client
+        ? executeOctagonAgentTool(
+            client,
+            { prompt, conversation, newConversation },
+            extra,
+          )
+        : Promise.resolve(createMissingApiKeyResult()),
   );
 }

--- a/src/tools/predictionMarketsAgent.ts
+++ b/src/tools/predictionMarketsAgent.ts
@@ -3,7 +3,11 @@ import OpenAI from "openai";
 import { z } from "zod";
 
 import { type SessionExtra } from "../toolSessionState.js";
-import { createStreamingTextResponse, createTextErrorResult } from "#tools/shared";
+import {
+  createMissingApiKeyResult,
+  createStreamingTextResponse,
+  createTextErrorResult,
+} from "#tools/shared";
 
 const AGENT_NAME = "octagon-prediction-markets-agent";
 const AGENT_DESCRIPTION =
@@ -52,7 +56,7 @@ export async function executePredictionMarketsTool(
   }
 }
 
-export function registerTool(server: McpServer, client: OpenAI): void {
+export function registerTool(server: McpServer, client: OpenAI | null): void {
   const toolServer = server as unknown as {
     tool: (
       name: string,
@@ -66,6 +70,9 @@ export function registerTool(server: McpServer, client: OpenAI): void {
     AGENT_NAME,
     AGENT_DESCRIPTION,
     predictionMarketsInputShape,
-    async (args, extra) => executePredictionMarketsTool(client, args, extra),
+    async (args, extra) =>
+      client
+        ? executePredictionMarketsTool(client, args, extra)
+        : Promise.resolve(createMissingApiKeyResult()),
   );
 }

--- a/src/tools/predictionMarketsHistory.ts
+++ b/src/tools/predictionMarketsHistory.ts
@@ -3,6 +3,7 @@ import OpenAI, { APIError } from "openai";
 import { z } from "zod";
 
 import { type SessionExtra } from "../toolSessionState.js";
+import { createMissingApiKeyResult } from "#tools/shared";
 
 const TOOL_NAME = "prediction_markets_history";
 const TOOL_DESCRIPTION = `Fetch historical data for a prediction market event by ticker.
@@ -116,7 +117,7 @@ export async function executePredictionMarketsHistoryTool(
   }
 }
 
-export function registerTool(server: McpServer, client: OpenAI): void {
+export function registerTool(server: McpServer, client: OpenAI | null): void {
   const toolServer = server as unknown as {
     tool: (
       name: string,
@@ -131,10 +132,12 @@ export function registerTool(server: McpServer, client: OpenAI): void {
     TOOL_DESCRIPTION,
     predictionMarketsHistoryInputShape,
     async (params, extra) =>
-      executePredictionMarketsHistoryTool(
-        client as PredictionMarketsHistoryClient,
-        params,
-        extra,
-      ),
+      client
+        ? executePredictionMarketsHistoryTool(
+            client as PredictionMarketsHistoryClient,
+            params,
+            extra,
+          )
+        : Promise.resolve(createMissingApiKeyResult()),
   );
 }

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -229,3 +229,9 @@ export function createTextErrorResult(message: string) {
     content: [{ type: "text" as const, text: message }],
   };
 }
+
+export function createMissingApiKeyResult() {
+  return createTextErrorResult(
+    "Error: OCTAGON_API_KEY is not set. Configure OCTAGON_API_KEY to use Octagon API-backed tools. Documentation tools remain available without an API key.",
+  );
+}

--- a/tests/docs-catalog.test.js
+++ b/tests/docs-catalog.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDocsCatalog } from "../dist/docs/catalog.js";
+
+const fetched = {
+  url: "https://octagonai.co/docs/llms.txt",
+  finalUrl: "https://octagonai.co/docs/llms.txt",
+  fetchedAt: "2026-06-02T12:00:00.000Z",
+  text: `# Octagon AI
+
+## API Documentation
+
+- [Authentication Guide](https://docs.octagonagents.com/docs/guide/rest-api/authentication.html.md): API key setup.
+- [Responses API](/docs/guide/rest-api/responses.html.md): Structured responses.
+
+## Claude Plugin
+
+Install the plugin from Claude and connect the Octagon AI connector.
+`,
+};
+
+test("parseDocsCatalog indexes headings and links", () => {
+  const catalog = parseDocsCatalog(fetched, {
+    source: "docs",
+    cacheTtlMs: 60_000,
+  });
+
+  assert.equal(catalog.source, "docs");
+  assert.equal(catalog.sourceUrl, "https://octagonai.co/docs/llms.txt");
+  assert.ok(catalog.entries.some(entry => entry.title === "API Documentation"));
+  assert.ok(catalog.entries.some(entry => entry.title === "Authentication Guide"));
+  assert.ok(catalog.entries.some(entry => entry.title === "Responses API"));
+  assert.ok(catalog.sections.includes("Octagon AI"));
+});
+
+test("parseDocsCatalog normalizes relative links against source URL", () => {
+  const catalog = parseDocsCatalog(fetched, { source: "docs" });
+  const responses = catalog.entries.find(entry => entry.title === "Responses API");
+
+  assert.equal(
+    responses?.url,
+    "https://octagonai.co/docs/guide/rest-api/responses.html.md",
+  );
+});
+
+test("parseDocsCatalog seeds primary guide pages for discoverability", () => {
+  const catalog = parseDocsCatalog(fetched, { source: "docs" });
+
+  assert.equal(
+    catalog.entries.find(entry => entry.title === "Octagon Claude Plugin")?.url,
+    "https://octagonai.co/docs/guide/claude-plugin",
+  );
+  assert.equal(
+    catalog.entries.find(entry => entry.title === "Octagon MCP Server")?.url,
+    "https://octagonai.co/docs/guide/mcp-server",
+  );
+  assert.equal(
+    catalog.entries.find(entry => entry.title === "Octagon Agents Guide")?.url,
+    "https://octagonai.co/docs/guide/agents/",
+  );
+});

--- a/tests/docs-corpus.test.js
+++ b/tests/docs-corpus.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDocsCatalog } from "../dist/docs/catalog.js";
+
+test("docs corpus shape is split into searchable section pages", () => {
+  const catalog = parseDocsCatalog(
+    {
+      url: "https://octagonai.co/docs/llms.txt",
+      finalUrl: "https://octagonai.co/docs/llms.txt",
+      fetchedAt: "2026-06-02T12:00:00.000Z",
+      text: `Source URL: https://octagonai.co/docs/llms.txt
+Title: Octagon AI
+
+# Octagon AI
+
+> Octagon provides specialized investment research Agents.
+
+# How Octagon API Works
+
+## API Architecture and Integration
+
+The Octagon API is built to be compatible with the OpenAI API format.
+
+## Core Concepts
+
+1. **Agents**: Specialized AI models.
+2. **Responses API**: Enhanced response format.
+
+## API Documentation
+
+- [Authentication Guide](https://docs.octagonagents.com/docs/guide/rest-api/authentication.html.md): This section walks through the authentication process.
+`,
+    },
+    { source: "docs" },
+  );
+
+  const architecture = catalog.entries.find(
+    entry => entry.title === "API Architecture and Integration",
+  );
+  const auth = catalog.entries.find(entry => entry.title === "Authentication Guide");
+
+  assert.equal(architecture?.kind, "section");
+  assert.match(architecture?.content ?? "", /OpenAI API format/);
+  assert.equal(auth?.kind, "link");
+  assert.match(auth?.summary ?? "", /authentication process/);
+});

--- a/tests/docs-fetcher.test.js
+++ b/tests/docs-fetcher.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertAllowedDocsUrl,
+  fetchDocsText,
+} from "../dist/docs/fetcher.js";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("assertAllowedDocsUrl rejects unsupported hosts", () => {
+  assert.throws(
+    () => assertAllowedDocsUrl("https://example.com/docs/llms.txt"),
+    /Unsupported docs URL host/,
+  );
+});
+
+test("fetchDocsText returns text and cache headers", async () => {
+  globalThis.fetch = async () =>
+    new Response("# Docs", {
+      status: 200,
+      headers: {
+        "content-type": "text/markdown",
+        etag: '"abc"',
+        "last-modified": "Tue, 02 Jun 2026 12:00:00 GMT",
+      },
+    });
+
+  const result = await fetchDocsText("https://octagonai.co/docs/llms.txt");
+
+  assert.equal(result.text, "# Docs");
+  assert.equal(result.contentType, "text/markdown");
+  assert.equal(result.etag, '"abc"');
+  assert.equal(result.lastModified, "Tue, 02 Jun 2026 12:00:00 GMT");
+});
+
+test("fetchDocsText reports non-2xx responses", async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response("missing", { status: 404 });
+  };
+
+  await assert.rejects(
+    fetchDocsText("https://octagonai.co/docs/missing.md", {
+      retryCount: 2,
+      retryDelayMs: 0,
+    }),
+    /HTTP 404/,
+  );
+  assert.equal(calls, 1);
+});
+
+test("fetchDocsText retries transient fetch failures", async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      throw new TypeError("fetch failed");
+    }
+
+    return new Response("# Docs after retry", {
+      status: 200,
+      headers: { "content-type": "text/markdown" },
+    });
+  };
+
+  const result = await fetchDocsText("https://octagonai.co/docs/llms.txt", {
+    retryCount: 1,
+    retryDelayMs: 0,
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.text, "# Docs after retry");
+});
+
+test("fetchDocsText retries temporary server errors", async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      return new Response("temporary", { status: 503 });
+    }
+
+    return new Response("# Docs after 503", {
+      status: 200,
+      headers: { "content-type": "text/markdown" },
+    });
+  };
+
+  const result = await fetchDocsText("https://octagonai.co/docs/llms.txt", {
+    retryCount: 1,
+    retryDelayMs: 0,
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.text, "# Docs after 503");
+});

--- a/tests/docs-search.test.js
+++ b/tests/docs-search.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { searchDocsEntries } from "../dist/docs/search.js";
+
+const entries = [
+  {
+    id: "docs:authentication-guide",
+    title: "Authentication Guide",
+    url: "https://octagonai.co/docs/guide/rest-api/authentication",
+    path: "/docs/guide/rest-api/authentication",
+    section: "REST API",
+    source: "docs",
+    kind: "link",
+    summary: "API key setup and Authorization header examples.",
+  },
+  {
+    id: "docs:claude-plugin",
+    title: "Octagon Claude Plugin",
+    url: "https://octagonai.co/docs/guide/claude-plugin",
+    path: "/docs/guide/claude-plugin",
+    section: "Plugin",
+    source: "docs",
+    kind: "section",
+    content:
+      "Install the plugin in Claude, then install and connect the Octagon AI connector.",
+  },
+  {
+    id: "docs:complete-python-integration-example",
+    title: "Complete Python integration example",
+    url: "https://octagonai.co/docs/llms.txt#complete-python-integration-example",
+    path: "/docs/llms.txt#complete-python-integration-example",
+    section: "Integration Examples",
+    source: "docs",
+    kind: "section",
+    content: "Complete Python integration example using the OpenAI client.",
+  },
+];
+
+test("searchDocsEntries ranks title and content matches", () => {
+  const results = searchDocsEntries(entries, {
+    query: "Claude connector",
+    limit: 5,
+    includeSnippets: true,
+  });
+
+  assert.equal(results[0].entry.title, "Octagon Claude Plugin");
+  assert.match(results[0].snippet ?? "", /connector/);
+});
+
+test("searchDocsEntries filters by section", () => {
+  const results = searchDocsEntries(entries, {
+    query: "API key",
+    section: "REST",
+    limit: 5,
+    includeSnippets: false,
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].entry.title, "Authentication Guide");
+});
+
+test("searchDocsEntries suppresses generic-only integration matches", () => {
+  const results = searchDocsEntries(entries, {
+    query: "Claude plugin MCP integration",
+    limit: 5,
+    includeSnippets: true,
+  });
+
+  assert.equal(results[0].entry.title, "Octagon Claude Plugin");
+  assert.equal(
+    results.some(
+      result => result.entry.title === "Complete Python integration example",
+    ),
+    false,
+  );
+});

--- a/tests/docs-tools.test.js
+++ b/tests/docs-tools.test.js
@@ -75,6 +75,56 @@ test("docs read tool reads cached corpus content", async () => {
   assert.equal(result.structuredContent.truncated, false);
 });
 
+test("docs service expires cached reads when catalog refreshes", async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    const connectorText =
+      calls === 1 ? "first connector text" : "second connector text";
+
+    return new Response(
+      `# Octagon AI
+
+## Octagon Claude Plugin
+
+The Octagon Claude Plugin uses ${connectorText}.
+`,
+      {
+        status: 200,
+        headers: { "content-type": "text/markdown" },
+      },
+    );
+  };
+
+  const service = new OctagonDocsService({
+    primaryIndexUrl: "https://octagonai.co/docs/llms.txt",
+    cacheTtlMs: -1,
+  });
+
+  const first = await service.read({
+    target: "Octagon Claude Plugin",
+    maxChars: 2000,
+  });
+  const second = await service.read({
+    target: "Octagon Claude Plugin",
+    maxChars: 2000,
+  });
+
+  assert.match(first.markdown, /first connector text/);
+  assert.match(second.markdown, /second connector text/);
+  assert.equal(calls, 2);
+});
+
+test("docs read tool handles malformed percent-encoded targets", async () => {
+  const result = await executeDocsReadTool(createMockedService(), {
+    target: "50%",
+    maxChars: 2000,
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /No Octagon docs page matched/);
+});
+
 test("docs read tool fetches direct docs URLs even when not cataloged", async () => {
   globalThis.fetch = async url => {
     if (String(url) === "https://octagonai.co/docs/llms.txt") {

--- a/tests/docs-tools.test.js
+++ b/tests/docs-tools.test.js
@@ -29,6 +29,15 @@ const docsWithLegacyLinks = `# Octagon AI
 - [Available Agents](https://docs.octagonagents.com/docs/guide/agents.html.md): Agent capabilities and model selection.
 `;
 
+const docsWithGettingStarted = `# Octagon AI
+
+# How Octagon API Works
+
+## Getting Started with Code Examples
+
+Use the OpenAI-compatible Octagon API with your Octagon API key.
+`;
+
 test.afterEach(() => {
   globalThis.fetch = originalFetch;
 });
@@ -73,6 +82,28 @@ test("docs read tool reads cached corpus content", async () => {
 
   assert.match(result.content[0].text, /Octagon AI connector/);
   assert.equal(result.structuredContent.truncated, false);
+});
+
+test("docs read tool accepts list display labels with section names", async () => {
+  globalThis.fetch = async () =>
+    new Response(docsWithGettingStarted, {
+      status: 200,
+      headers: { "content-type": "text/markdown" },
+    });
+
+  const service = new OctagonDocsService({
+    primaryIndexUrl: "https://octagonai.co/docs/llms.txt",
+  });
+  const result = await executeDocsReadTool(service, {
+    target: "Getting Started with Code Examples (How Octagon API Works)",
+    maxChars: 2000,
+  });
+
+  assert.match(result.content[0].text, /OpenAI-compatible Octagon API/);
+  assert.equal(
+    result.structuredContent.entry.title,
+    "Getting Started with Code Examples",
+  );
 });
 
 test("docs service expires cached reads when catalog refreshes", async () => {

--- a/tests/docs-tools.test.js
+++ b/tests/docs-tools.test.js
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { OctagonDocsService } from "../dist/docs/index.js";
+import {
+  executeDocsListTool,
+  executeDocsReadTool,
+  executeDocsRefreshTool,
+  executeDocsSearchTool,
+} from "../dist/docs/tools.js";
+
+const originalFetch = globalThis.fetch;
+
+const docsMarkdown = `# Octagon AI
+
+## Octagon Claude Plugin
+
+The Octagon Claude Plugin uses the Octagon AI connector for authentication.
+
+## MCP Server
+
+- [MCP Server Guide](https://octagonai.co/docs/guide/mcp-server): Model Context Protocol integration.
+`;
+
+const docsWithLegacyLinks = `# Octagon AI
+
+## API Documentation
+
+- [Available Agents](https://docs.octagonagents.com/docs/guide/agents.html.md): Agent capabilities and model selection.
+`;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function createMockedService() {
+  globalThis.fetch = async () =>
+    new Response(docsMarkdown, {
+      status: 200,
+      headers: { "content-type": "text/markdown" },
+    });
+
+  return new OctagonDocsService({
+    primaryIndexUrl: "https://octagonai.co/docs/llms.txt",
+    cacheTtlMs: 60_000,
+  });
+}
+
+test("docs list tool returns structured entries", async () => {
+  const result = await executeDocsListTool(createMockedService(), { limit: 5 });
+
+  assert.equal(result.structuredContent.count > 0, true);
+  assert.match(result.content[0].text, /Octagon Claude Plugin/);
+});
+
+test("docs search tool returns snippets and source URLs", async () => {
+  const result = await executeDocsSearchTool(createMockedService(), {
+    query: "Claude connector",
+    includeSnippets: true,
+  });
+
+  assert.equal(result.structuredContent.count >= 1, true);
+  assert.equal(result.structuredContent.results[0].title, "Octagon Claude Plugin");
+  assert.match(result.structuredContent.results[0].snippet, /connector/);
+  assert.match(result.structuredContent.results[0].url, /claude-plugin/);
+});
+
+test("docs read tool reads cached corpus content", async () => {
+  const result = await executeDocsReadTool(createMockedService(), {
+    target: "Octagon Claude Plugin",
+    maxChars: 2000,
+  });
+
+  assert.match(result.content[0].text, /Octagon AI connector/);
+  assert.equal(result.structuredContent.truncated, false);
+});
+
+test("docs read tool fetches direct docs URLs even when not cataloged", async () => {
+  globalThis.fetch = async url => {
+    if (String(url) === "https://octagonai.co/docs/llms.txt") {
+      return new Response(docsMarkdown, {
+        status: 200,
+        headers: { "content-type": "text/markdown" },
+      });
+    }
+
+    assert.equal(String(url), "https://octagonai.co/docs/guide/mcp-server");
+    return new Response("# Octagon MCP Server\n\nDirect page content.", {
+      status: 200,
+      headers: { "content-type": "text/markdown" },
+    });
+  };
+
+  const service = new OctagonDocsService({
+    primaryIndexUrl: "https://octagonai.co/docs/llms.txt",
+  });
+  const result = await executeDocsReadTool(service, {
+    target: "https://docs.octagonai.co/guide/mcp-server.html",
+    maxChars: 2000,
+  });
+
+  assert.match(result.content[0].text, /Direct page content/);
+  assert.equal(
+    result.structuredContent.canonicalUrl,
+    "https://octagonai.co/docs/guide/mcp-server",
+  );
+});
+
+test("docs read tool modernizes legacy docs links before fetching", async () => {
+  globalThis.fetch = async url => {
+    if (String(url) === "https://octagonai.co/docs/llms.txt") {
+      return new Response(docsWithLegacyLinks, {
+        status: 200,
+        headers: { "content-type": "text/markdown" },
+      });
+    }
+
+    assert.equal(String(url), "https://octagonai.co/docs/guide/agents");
+    return new Response("# Octagon Agents\n\nAvailable agent docs.", {
+      status: 200,
+      headers: { "content-type": "text/markdown" },
+    });
+  };
+
+  const service = new OctagonDocsService({
+    primaryIndexUrl: "https://octagonai.co/docs/llms.txt",
+  });
+  const result = await executeDocsReadTool(service, {
+    target: "Available Agents",
+    maxChars: 2000,
+  });
+
+  assert.match(result.content[0].text, /Available agent docs/);
+});
+
+test("docs refresh tool reports refreshed catalogs", async () => {
+  const result = await executeDocsRefreshTool(createMockedService(), {});
+
+  assert.match(result.content[0].text, /docs:/);
+  assert.equal(result.structuredContent.catalogs[0].entries > 0, true);
+});

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -23,7 +23,7 @@ test("plugin manifest exposes the bundled MCP runtime and required config", () =
   assert.equal(pluginManifest.mcpServers, "./.claude-plugin/mcp.json");
   assert.ok(!("hooks" in pluginManifest));
   assert.equal(pluginManifest.userConfig.api_key.required, true);
-  assert.equal(pluginManifest.userConfig.api_key.sensitive, false);
+  assert.equal(pluginManifest.userConfig.api_key.sensitive, true);
   assert.equal(
     pluginManifest.userConfig.api_base_url.default,
     "https://api.octagonagents.com/v1",

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(path.join(repoRoot, relativePath), "utf8"));
+}
+
+function readText(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("plugin manifest exposes the bundled MCP runtime and required config", () => {
+  const pluginManifest = readJson(".claude-plugin/plugin.json");
+  const mcpConfig = readJson(".claude-plugin/mcp.json");
+
+  assert.equal(pluginManifest.name, "octagon-market-intelligence");
+  assert.equal(pluginManifest.mcpServers, "./.claude-plugin/mcp.json");
+  assert.ok(!("hooks" in pluginManifest));
+  assert.equal(pluginManifest.userConfig.api_key.required, true);
+  assert.equal(pluginManifest.userConfig.api_key.sensitive, false);
+  assert.equal(
+    pluginManifest.userConfig.api_base_url.default,
+    "https://api.octagonagents.com/v1",
+  );
+
+  assert.deepEqual(mcpConfig.mcpServers["octagon-mcp"], {
+    command: "node",
+    args: ["${CLAUDE_PLUGIN_ROOT}/dist/plugin-runtime.cjs"],
+    env: {
+      OCTAGON_API_KEY: "${user_config.api_key}",
+      OCTAGON_API_BASE_URL: "${user_config.api_base_url}",
+    },
+  });
+});
+
+test("plugin package publishes Claude plugin assets alongside dist output", () => {
+  const packageJson = readJson("package.json");
+
+  for (const requiredEntry of [
+    ".claude-plugin",
+    "agents",
+    "dist",
+    "hooks",
+    "scripts",
+    "skills",
+  ]) {
+    assert.ok(packageJson.files.includes(requiredEntry));
+  }
+});
+
+test("skills catalog includes the expected v1 workflows", () => {
+  const skillNames = [
+    "octagon-analyst-master",
+    "analyst-estimates",
+    "prediction-markets-analysis",
+    "earnings-call-analysis",
+    "sec-10k-analysis",
+    "stock-quote",
+    "octagon-api-smoke-test",
+  ];
+
+  for (const skillName of skillNames) {
+    const skillPath = path.join(repoRoot, "skills", skillName, "SKILL.md");
+    assert.ok(existsSync(skillPath), `${skillName} skill should exist`);
+    const skillText = readText(path.join("skills", skillName, "SKILL.md"));
+    assert.match(skillText, new RegExp(`name: ${skillName}`));
+    assert.match(skillText, /server": "octagon-mcp"/);
+  }
+});
+
+test("routing agent and session-start hook are wired into the plugin", () => {
+  const hooksConfig = readJson("hooks/hooks.json");
+  const agentPath = path.join(
+    repoRoot,
+    "agents",
+    "octagon-research-orchestrator.md",
+  );
+  const hookScriptPath = path.join(repoRoot, "scripts", "plugin-session-start.sh");
+  const agentText = readText(path.join("agents", "octagon-research-orchestrator.md"));
+
+  assert.ok(existsSync(agentPath));
+  assert.ok(existsSync(hookScriptPath));
+  assert.equal(
+    hooksConfig.hooks.SessionStart[0].hooks[0].command,
+    "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/plugin-session-start.sh",
+  );
+  assert.match(agentText, /name: octagon-research-orchestrator/);
+  assert.match(agentText, /octagon-analyst-master/);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude plugin manifest, local MCP/server entry, session-start hook, and plugin packaging updates
  * Live documentation tools: catalog, search, read, and refresh; docs service and resources endpoints
  * New investment research skills and orchestrator agent; API-smoke-test and stock/prediction/SEC skills
  * Graceful behavior when API key is missing (docs remain available)

* **Documentation**
  * README updated with docs links, tool descriptions, and hosted MCP setup guidance

* **Tests**
  * Added comprehensive tests for docs parsing, fetching, search, tools, and plugin manifest
<!-- end of auto-generated comment: release notes by coderabbit.ai -->