### PR TITLE
Update homepage and documentation domain

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "name": "Octagon AI",
     "url": "https://github.com/OctagonAI/octagon-mcp-server"
   },
-  "homepage": "https://docs.octagonagents.com",
+  "homepage": "https://octagonai.co/docs",
   "repository": "https://github.com/OctagonAI/octagon-mcp-server",
   "license": "MIT",
   "keywords": [
@@ -33,7 +33,7 @@
       "type": "string",
       "title": "Octagon API base URL",
       "description": "Optional override for staging, private environments, or self-hosted Octagon API deployments.",
-      "default": "https://api.octagonagents.com/v1"
+      "default": "https://api.octagonai.co/v1"
     }
   }
 }

--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@
 OCTAGON_API_KEY=your_octagon_api_key_here
 
 # Base URL for Octagon API
-OCTAGON_API_BASE_URL=https://api.octagonagents.com/v1 
+OCTAGON_API_BASE_URL=https://api.octagonai.co/v1

--- a/package.json
+++ b/package.json
@@ -75,5 +75,5 @@
   "bugs": {
     "url": "https://github.com/OctagonAI/octagon-mcp-server/issues"
   },
-  "homepage": "https://docs.octagonagents.com"
+  "homepage": "https://octagonai.co/docs"
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,7 @@ type ClientOptions = Omit<OpenAIClientOptions, "apiKey" | "baseURL">;
 
 const OCTAGON_API_KEY = process.env.OCTAGON_API_KEY;
 const OCTAGON_API_BASE_URL =
-  process.env.OCTAGON_API_BASE_URL || "https://api.octagonagents.com/v1";
+  process.env.OCTAGON_API_BASE_URL || "https://api.octagonai.co/v1";
 
 // Initialize OpenAI client with Octagon API
 const createClient = (options: ClientOptions) => {

--- a/src/docs/config.ts
+++ b/src/docs/config.ts
@@ -5,7 +5,6 @@ export const DOCS_ALLOWED_HOSTS = new Set([
   "octagonai.co",
   "www.octagonai.co",
   "docs.octagonai.co",
-  "docs.octagonagents.com",
 ]);
 
 export const DOCS_DEFAULT_TIMEOUT_MS = 10_000;

--- a/src/docs/content.ts
+++ b/src/docs/content.ts
@@ -90,7 +90,7 @@ function candidateMarkdownUrls(url: string): string[] {
 function modernizeDocsUrl(url: URL): string | undefined {
   let pathname = url.pathname;
 
-  if (url.hostname === "docs.octagonagents.com") {
+  if (url.hostname === "docs.octagonai.co") {
     pathname = pathname.replace(/^\/docs/, "");
   }
 

--- a/tests/docs-catalog.test.js
+++ b/tests/docs-catalog.test.js
@@ -11,8 +11,8 @@ const fetched = {
 
 ## API Documentation
 
-- [Authentication Guide](https://docs.octagonagents.com/docs/guide/rest-api/authentication.html.md): API key setup.
-- [Responses API](/docs/guide/rest-api/responses.html.md): Structured responses.
+- [Authentication Guide](https://octagonai.co/docs/guide/rest-api/authentication): API key setup.
+- [Responses API](https://octagonai.co/docs/guide/rest-api/responses): Structured responses.
 
 ## Claude Plugin
 
@@ -40,7 +40,7 @@ test("parseDocsCatalog normalizes relative links against source URL", () => {
 
   assert.equal(
     responses?.url,
-    "https://octagonai.co/docs/guide/rest-api/responses.html.md",
+    "https://octagonai.co/docs/guide/rest-api/responses",
   );
 });
 

--- a/tests/docs-corpus.test.js
+++ b/tests/docs-corpus.test.js
@@ -29,7 +29,7 @@ The Octagon API is built to be compatible with the OpenAI API format.
 
 ## API Documentation
 
-- [Authentication Guide](https://docs.octagonagents.com/docs/guide/rest-api/authentication.html.md): This section walks through the authentication process.
+- [Authentication Guide](https://octagonai.co/docs/guide/rest-api/authentication): This section walks through the authentication process.
 `,
     },
     { source: "docs" },

--- a/tests/docs-tools.test.js
+++ b/tests/docs-tools.test.js
@@ -26,7 +26,7 @@ const docsWithLegacyLinks = `# Octagon AI
 
 ## API Documentation
 
-- [Available Agents](https://docs.octagonagents.com/docs/guide/agents.html.md): Agent capabilities and model selection.
+- [Available Agents](https://octagonai.co/docs/guide/agents): Agent capabilities and model selection.
 `;
 
 const docsWithGettingStarted = `# Octagon AI

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -26,7 +26,7 @@ test("plugin manifest exposes the bundled MCP runtime and required config", () =
   assert.equal(pluginManifest.userConfig.api_key.sensitive, true);
   assert.equal(
     pluginManifest.userConfig.api_base_url.default,
-    "https://api.octagonagents.com/v1",
+    "https://api.octagonai.co/v1",
   );
 
   assert.deepEqual(mcpConfig.mcpServers["octagon-mcp"], {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default API base URL to use the new service domain.
  * Updated documentation homepage and the set of allowed documentation hosts.
  * Refreshed environment configuration templates to match the new API endpoint.
* **Tests**
  * Updated documentation link fixtures and assertions to reflect the new canonical docs URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->