### PR TITLE
docs: replace broken Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Octagon: MCP for Public & Prediction Markets Intelligence
 
-[![smithery badge](https://smithery.ai/badge/@OctagonAI/octagon-mcp-server)](https://smithery.ai/server/@OctagonAI/octagon-mcp-server)
+[![LightNow](https://lightnow.ai/badge/io.github.octagonai/octagon-mcp-server)](https://lightnow.ai/servers/io.github.octagonai/octagon-mcp-server)
 
 ![Favicon](https://octagonai.co/docs/logo.svg) The Octagon MCP server provides specialized AI-powered financial research and analysis by integrating with the Octagon Market Intelligence API, enabling users to analyze and extract insights from public filings, earnings calls, financial metrics, stocks & crypto data, stock news, and prediction markets news & research within Claude Desktop and other popular MCP clients.
 


### PR DESCRIPTION
## Summary

Replaces the broken Smithery badge with the matching LightNow capability badge.

- Server: https://lightnow.ai/servers/io.github.octagonai/octagon-mcp-server
- Badge docs and variants: https://docs.lightnow.ai/how-to/add-capability-badge/

## Validation

- Verified the badge SVG and server page return successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README badge to reference LightNow instead of Smithery.
  - Updated the badge link and image source for the Octagon MCP server listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->